### PR TITLE
Update Dependencies and Interim Fix for `ONLY_FULL_GROUP_BY` SQL Mode Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Upgrade NumPy from 1.22.3 to 1.23.2
   - Upgrade pytz from 2022.1 to 2022.2.1
 
+### Application Changes
+
+- Add an additional query that unsets `ONLY_FULL_GROUP_BY` flag and sets the appropriate flags for the session-level `sql_mode` for queries that return an error due to MySQL Server setting the `ONLY_FULL_GROUP_BY` flag by default. Queries and application logic for the respective functions will need to be rearchitected in a future release.
+
 ## 2.1.2
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 2.1.3
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.5 to 2.0.7, which also includes the following changes:
+  - Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
+  - Upgrade NumPy from 1.22.3 to 1.23.2
+  - Upgrade pytz from 2022.1 to 2022.2.1
+
 ## 2.1.2
 
 ### Component Changes

--- a/app/reports/show/bluff_count.py
+++ b/app/reports/show/bluff_count.py
@@ -35,6 +35,17 @@ def build_bluff_data_year_month_dict() -> List[Dict]:
     """Returns an dictionary that will be used to populate Bluff the
     Listener data for all years and months"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
+
     cursor = database_connection.cursor(named_tuple=True)
     query = (
         "SELECT date_format(s.showdate, '%b %Y') AS date "
@@ -67,6 +78,16 @@ def retrieve_all_bluff_counts():
     broken down by month"""
     bluff_data = build_bluff_data_year_month_dict()
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
 
     # Retrieve counts where listener contestant chose the
     # correct Bluff story
@@ -127,6 +148,16 @@ def retrieve_bluff_count_year(year: int) -> Dict:
     broken down by month"""
     bluff_data = build_bluff_data_dict()
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
 
     # Retrieve counts where listener contestant chose the
     # correct Bluff story

--- a/app/reports/show/scores.py
+++ b/app/reports/show/scores.py
@@ -35,6 +35,17 @@ def build_all_scoring_dict() -> Dict:
     """Returns an dictionary that contains scoring dictionaries used to
     populate all panelist scoring data"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
+
     cursor = database_connection.cursor(named_tuple=True)
     query = (
         "SELECT DISTINCT YEAR(s.showdate) AS year "
@@ -67,6 +78,17 @@ def retrieve_monthly_aggregate_scores() -> Dict:
     """Retrieve aggregated panelist scores grouped by month for every
     available year"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
+
     cursor = database_connection.cursor(named_tuple=True)
     query = (
         "SELECT YEAR(s.showdate) AS year, "
@@ -101,6 +123,17 @@ def retrieve_monthly_average_scores() -> Dict:
     """Retrieve average panelist scores grouped by month
     for every available year"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
+
     cursor = database_connection.cursor(named_tuple=True)
     query = (
         "SELECT YEAR(s.showdate) AS year, "

--- a/app/reports/show/show_counts.py
+++ b/app/reports/show/show_counts.py
@@ -15,6 +15,17 @@ def retrieve_show_counts_by_year() -> Dict[int, int]:
     """Retrieve the number of Regular, Best Of, Repeat and Repeat/Best
     Of shows broken down by year"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
+
+    # Override session SQL mode value to unset ONLY_FULL_GROUP_BY
+    cursor = database_connection.cursor(dictionary=False)
+    query = (
+        "SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,"
+        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
+    )
+    cursor.execute(query)
+    _ = cursor.fetchall()
+    cursor.close()
+
     years = []
     cursor = database_connection.cursor(named_tuple=True)
     query = (

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Errors module for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.1.2"
+APP_VERSION = "2.1.3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ black==22.6.0
 
 Flask==2.2.0
 Werkzeug==2.2.1
-pytz==2022.1
+pytz==2022.2.1
 gunicorn==20.1.0
 
-wwdtm==2.0.5
+wwdtm==2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.2.0
 Werkzeug==2.2.1
-pytz==2022.1
+pytz==2022.2.1
 gunicorn==20.1.0
 
-wwdtm==2.0.5
+wwdtm==2.0.7


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.0.5 to 2.0.7, which also includes the following changes:
  - Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
  - Upgrade NumPy from 1.22.3 to 1.23.2
  - Upgrade pytz from 2022.1 to 2022.2.1

## Application Changes

- Add an additional query that unsets `ONLY_FULL_GROUP_BY` flag and sets the appropriate flags for the session-level `sql_mode` for queries that return an error due to MySQL Server setting the `ONLY_FULL_GROUP_BY` flag by default. Queries and application logic for the respective functions will need to be rearchitected in a future release.