### PR TITLE
Fix Incorrect Route Within panelists.routes.score_breakdown_details()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugfix
 
-- Fix an issue where an incorrect route was being referenced in `panelists.routes.core_breakdown_details()`, causing an unhandled error
+- Fix an issue where an incorrect route was being referenced in `panelists.routes.score_breakdown_details()`, causing an unhandled error
 
 ## 2.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.1.4
+
+### Bugfix
+
+- Fix an issue where an incorrect route was being referenced in `panelists.routes.core_breakdown_details()`, causing an unhandled error
+
 ## 2.1.3
 
 ### Component Changes

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -104,7 +104,7 @@ def score_breakdown_details(panelist: str):
     info = _panelist.retrieve_by_slug(panelist)
 
     if not info:
-        return redirect_url(url_for("panelists_score_breakdown_index"))
+        return redirect_url(url_for("panelists.score_breakdown"))
 
     _panelist_scores = PanelistScores(database_connection=database_connection)
     scores = _panelist_scores.retrieve_scores_grouped_list_by_slug(panelist)

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Errors module for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.1.3"
+APP_VERSION = "2.1.4"


### PR DESCRIPTION
## Bugfix

- Fix an issue where an incorrect route was being referenced in `panelists.routes.score_breakdown_details()`, causing an unhandled error