### PR TITLE
Re-work configuration, add Mastodon link support in footer and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changes
 
+## 2.1.6
+
+### Application Changes
+
+- Use `dict.get(key, default_value)` in `app/__init__.py` to get/set configuration values in order to avoid application startup errors if configuration keys are not set
+  - Default value for `time_zone` is `UTC`
+  - Default values for any URL is an empty string
+- Adding `mastodon_url` and `mastodon_user` configuration keys in the `settings` section of the config file
+- If the `mastodon_url` and `mastodon_user` keys contain a value, insert a link with `rel="me"` attribute for profile link validation, in the page footer
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.7 to 2.0.8, which also includes the following changes:
+  - Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
+  - Upgrade NumPy from 1.23.2 to 1.23.4
+  - Upgrade python-slugify from 5.0.2 to 6.1.2
+  - Upgrade pytz from 2022.2.1 to 2022.6
+- Upgrade Flask from 2.2.0 to 2.2.2
+- Upgrade Werkzeug from 2.2.1 to 2.2.2
+
+### Development Changes
+
+- Upgrade flake8 from 4.0.1 to 5.0.4
+- Upgrade pycodestyle from 2.8.0 to 2.9.1
+- Upgrade pytest from 7.1.2 to 7.2.0
+- Upgrade black from 22.6.0 to 22.10.0
+
+## 5.1.4
+
 ## 2.1.5
 
 ### Bugfix

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,15 +43,18 @@ def create_app():
     app.jinja_env.globals["current_year"] = utility.current_year
     app.jinja_env.globals["rendered_at"] = utility.generate_date_time_stamp
     app.jinja_env.globals["time_zone"] = app.config["app_settings"]["app_time_zone"]
-    app.jinja_env.globals["ga_property_code"] = app.config["app_settings"][
-        "ga_property_code"
-    ]
-    app.jinja_env.globals["api_url"] = app.config["app_settings"]["api_url"]
-    app.jinja_env.globals["blog_url"] = app.config["app_settings"]["blog_url"]
-    app.jinja_env.globals["repo_url"] = app.config["app_settings"]["repo_url"]
-    app.jinja_env.globals["reports_url"] = app.config["app_settings"]["reports_url"]
-    app.jinja_env.globals["site_url"] = app.config["app_settings"]["site_url"]
-    app.jinja_env.globals["stats_url"] = app.config["app_settings"]["stats_url"]
+    app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
+        "ga_property_code", ""
+    )
+    app.jinja_env.globals["api_url"] = _config["settings"].get("api_url", "")
+    app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")
+    app.jinja_env.globals["repo_url"] = _config["settings"].get("repo_url", "")
+    app.jinja_env.globals["reports_url"] = _config["settings"].get("reports_url", "")
+    app.jinja_env.globals["site_url"] = _config["settings"].get("site_url", "")
+    app.jinja_env.globals["mastodon_url"] = _config["settings"].get("mastodon_url", "")
+    app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
+        "mastodon_user", ""
+    )
 
     # Register application blueprints
     app.register_blueprint(main_bp)

--- a/app/config.py
+++ b/app/config.py
@@ -13,31 +13,33 @@ from app import utility
 
 
 def load_config(
-    config_file_path: str = "config.json", connection_pool_size: int = 12
+    config_file_path: str = "config.json",
+    connection_pool_size: int = 12,
+    connection_pool_name: str = "wwdtm_graphs",
+    app_time_zone: str = "UTC",
 ) -> Dict[str, Dict[str, Any]]:
     with open(config_file_path, "r") as config_file:
         app_config = json.load(config_file)
 
-    database_config = app_config["database"]
-    settings_config = app_config["settings"]
+    database_config = app_config.get("database", None)
+    settings_config = app_config.get("settings", None)
 
-    if "database" in app_config:
-        database_config = app_config["database"]
-
+    # Process database configuration settings
+    if database_config:
         # Set database connection pooling settings if and only if there
         # is a ``use_pool`` key and it is set to True. Remove the key
         # after parsing through the configuration to prevent issues
         # with mysql.connector.connect()
-        if "use_pool" in database_config and database_config["use_pool"]:
-            if "pool_name" not in database_config or not database_config["pool_name"]:
-                database_config["pool_name"] = "wwdtm_graphs"
+        use_pool = database_config.get("use_pool", False)
 
-            if "pool_size" not in database_config or not database_config["pool_size"]:
-                database_config["pool_size"] = connection_pool_size
+        if use_pool:
+            pool_name = database_config.get("pool_name", connection_pool_name)
+            pool_size = database_config.get("pool_size", connection_pool_size)
+            if pool_size < connection_pool_size:
+                pool_size = connection_pool_size
 
-            if "pool_size" in database_config and database_config["pool_size"] < 8:
-                database_config["pool_size"] = 8
-
+            database_config["pool_name"] = pool_name
+            database_config["pool_size"] = pool_size
             del database_config["use_pool"]
         else:
             if "pool_name" in database_config:
@@ -49,17 +51,12 @@ def load_config(
             if "use_pool" in database_config:
                 del database_config["use_pool"]
 
-    if "time_zone" in settings_config and settings_config["time_zone"]:
-        time_zone = settings_config["time_zone"]
-        time_zone_object, time_zone_string = utility.time_zone_parser(time_zone)
-
-        settings_config["app_time_zone"] = time_zone_object
-        database_config["time_zone"] = time_zone_string
-        settings_config["time_zone"] = time_zone_string
-    else:
-        settings_config["app_time_zone"] = pytz.timezone("UTC")
-        database_config["time_zone"] = "UTC"
-        settings_config["time_zone"] = "UTC"
+    # Process time zone configuration settings
+    time_zone = settings_config.get("time_zone", app_time_zone)
+    time_zone_object, time_zone_string = utility.time_zone_parser(time_zone)
+    settings_config["app_time_zone"] = time_zone_object
+    settings_config["time_zone"] = time_zone_string
+    database_config["time_zone"] = time_zone_string
 
     return {
         "database": database_config,

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -14,7 +14,13 @@
     </div>
     <div class="footer-copyright">
         <div class="container">
-            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }} <a href="https://linhpham.org/">Linh Pham</a>. All rights reserved.
+            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }}
+            {% if mastodon_url and mastodon_user %}
+            <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
+            {% else %}
+            <a href="https://linhpham.org/">Linh Pham</a>.
+            {% endif %}
+            All rights reserved.
             <span class="right">
                 <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
                 <span title="Application Version">V: {{ app_version }}</span> |

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Errors module for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.1.5"
+APP_VERSION = "2.1.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-required-version = "22.6.0"
-target-version = ["py38", "py39", "py310"]
+required-version = "22.10.0"
+target-version = ["py38", "py39", "py310", "py311"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
-flake8==4.0.1
-pycodestyle==2.8.0
-pytest==7.1.2
-black==22.6.0
+flake8==5.0.4
+pycodestyle==2.9.1
+pytest==7.2.0
+black==22.10.0
 
-Flask==2.2.0
-Werkzeug==2.2.1
-pytz==2022.2.1
+Flask==2.2.2
+Werkzeug==2.2.2
 gunicorn==20.1.0
 
-wwdtm==2.0.7
+wwdtm==2.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-Flask==2.2.0
-Werkzeug==2.2.1
-pytz==2022.2.1
+Flask==2.2.2
+Werkzeug==2.2.2
 gunicorn==20.1.0
 
-wwdtm==2.0.7
+wwdtm==2.0.8


### PR DESCRIPTION
## Application Changes

- Use `dict.get(key, default_value)` in `app/__init__.py` to get/set configuration values in order to avoid application startup errors if configuration keys are not set
  - Default value for `time_zone` is `UTC`
  - Default values for any URL is an empty string
- Adding `mastodon_url` and `mastodon_user` configuration keys in the `settings` section of the config file
- If the `mastodon_url` and `mastodon_user` keys contain a value, insert a link with `rel="me"` attribute for profile link validation, in the page footer

## Component Changes

- Upgrade wwdtm from 2.0.7 to 2.0.8, which also includes the following changes:
  - Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
  - Upgrade NumPy from 1.23.2 to 1.23.4
  - Upgrade python-slugify from 5.0.2 to 6.1.2
  - Upgrade pytz from 2022.2.1 to 2022.6
- Upgrade Flask from 2.2.0 to 2.2.2
- Upgrade Werkzeug from 2.2.1 to 2.2.2

## Development Changes

- Upgrade flake8 from 4.0.1 to 5.0.4
- Upgrade pycodestyle from 2.8.0 to 2.9.1
- Upgrade pytest from 7.1.2 to 7.2.0
- Upgrade black from 22.6.0 to 22.10.0