### PR TITLE
Add missing stats_url to app.jinja_env.globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.2.1
+
+### Application Changes
+
+- Fix issue with `stats_url` not being added to `app.jinja_env.globals` upon application startup
+
 ## 2.2.0
 
 ### Component Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,6 +51,7 @@ def create_app():
     app.jinja_env.globals["repo_url"] = _config["settings"].get("repo_url", "")
     app.jinja_env.globals["reports_url"] = _config["settings"].get("reports_url", "")
     app.jinja_env.globals["site_url"] = _config["settings"].get("site_url", "")
+    app.jinja_env.globals["stats_url"] = _config["settings"].get("stats_url", "")
     app.jinja_env.globals["mastodon_url"] = _config["settings"].get("mastodon_url", "")
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.2.0"
+APP_VERSION = "2.2.1"


### PR DESCRIPTION
## Application Changes

- Fix issue with `stats_url` not being added to `app.jinja_env.globals` upon application startup