### PR TITLE
Updating Flask and Werkzeug dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2.2.3
+
+### Component Changes
+
+- Upgrade Flask from 2.2.2 to 2.2.3
+- Upgrade Werkzeug from 2.2.2 to 2.2.3 to fix a security vulnerability
+
 ## 2.2.2
 
 ### Component Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.2.1"
+APP_VERSION = "2.2.3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ pycodestyle==2.9.1
 pytest==7.2.0
 black==22.10.0
 
-Flask==2.2.2
-Werkzeug==2.2.2
+Flask==2.2.3
+Werkzeug==2.2.3
 gunicorn==20.1.0
 
 wwdtm==2.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.2.2
-Werkzeug==2.2.2
+Flask==2.2.3
+Werkzeug==2.2.3
 gunicorn==20.1.0
 
 wwdtm==2.0.8


### PR DESCRIPTION
## Component Changes

- Upgrade Flask from 2.2.2 to 2.2.3
- Upgrade Werkzeug from 2.2.2 to 2.2.3 to fix a security vulnerability