### PR TITLE
Fix issue with Scores by Appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.1
+
+### Application Changes
+
+- Fix a bug with Panelists: Scores by Appearance route where panelists who have appearances on the show, but do not have corresponding scores, causes an error.
+
 ## 2.3.0
 
 ### Application Changes

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -166,8 +166,8 @@ def scores_by_appearance_details(panelist: str):
     if not info:
         return redirect_url(url_for("panelists.scores_by_appearance"))
 
-    shows_json = json.dumps(scores["shows"])
     if scores:
+        shows_json = json.dumps(scores["shows"])
         if current_app.config["app_settings"]["use_decimal_scores"]:
             scores_float = []
             for score in scores["scores"]:

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.3.0"
+APP_VERSION = "2.3.1"


### PR DESCRIPTION
## Application Changes

- Fix a bug with Panelists: Scores by Appearance route where panelists who have appearances on the show, but do not have corresponding scores, causes an error.