### PR TITLE
Upgrade to Flask 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes
 
+## 2.5.0
+
+### Component Changes
+
+- Upgrade Flask from 2.3.2 to 3.0.0
+- Upgrade gunicorn from 20.1.0 to 21.2.0
+
+### Development Changes
+
+- Upgrade pycodestyle from 2.11.0 to 2.11.1
+- Upgrade pytest from 7.4.0 to 7.4.3
+- Upgrade black from 23.7.0 to 23.10.1
+
 ## 2.4.0
 
 ### Component Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.4.0"
+APP_VERSION = "2.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.black]
-required-version = "23.7.0"
-target-version = ["py38", "py39", "py310", "py311"]
+required-version = "23.10.1"
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 flake8==6.1.0
-pycodestyle==2.11.0
-pytest==7.4.0
-black==23.7.0
+pycodestyle==2.11.1
+pytest==7.4.3
+black==23.10.1
 
-Flask==2.3.2
-gunicorn==20.1.0
+Flask==3.0.0
+gunicorn==21.2.0
 
 wwdtm==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.2
-gunicorn==20.1.0
+Flask==3.0.0
+gunicorn==21.2.0
 
 wwdtm==2.4.0


### PR DESCRIPTION
## Component Changes

- Upgrade Flask from 2.3.2 to 3.0.0
- Upgrade gunicorn from 20.1.0 to 21.2.0

## Development Changes

- Upgrade pycodestyle from 2.11.0 to 2.11.1
- Upgrade pytest from 7.4.0 to 7.4.3
- Upgrade black from 23.7.0 to 23.10.1