### PR TITLE
Upgrade to wwdtm 2.5.0, support Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changes
 
+## 2.6.0
+
+**Starting with version 2.6.0, support for all versions of Python prior to 3.10 have been deprecated.**
+
+### Application Changes
+
+- Replace `dateutil.parser.parse` with `datetime.datetime.strptime`
+
+### Component Changes
+
+- Upgrade wwdtm from 2.4.1 to 2.5.0, which drops supports for Python versions prior to 3.10 and includes:
+  - Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
+  - Upgrade numpy from 1.24.4 to 1.26.0
+
+### Development Changes
+
+- Upgrade black from 23.10.1 to 23.11.0
+- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
+- Bump minimum pytest version from 7.0 to 7.4 in `pyproject.toml`
+
 ## 2.5.0
 
 ### Component Changes

--- a/app/utility.py
+++ b/app/utility.py
@@ -6,7 +6,6 @@
 """Utility functions used by the Graphs Site"""
 
 from datetime import datetime
-from dateutil import parser
 from flask import current_app
 from typing import Any, Dict, List
 from mysql.connector import connect, DatabaseError
@@ -41,7 +40,7 @@ def date_string_to_date(**kwargs) -> datetime:
     """Used to convert an ISO-style date string into a datetime object"""
     if "date_string" in kwargs and kwargs["date_string"]:
         try:
-            date_object = parser.parse(kwargs["date_string"])
+            date_object = datetime.datetime.strptime(kwargs["date_string"], "%Y-%m-%d")
             return date_object
 
         except ValueError:

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.5.0"
+APP_VERSION = "2.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
-required-version = "23.10.1"
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+required-version = "23.11.0"
+target-version = ["py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
 minversion = "7.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 flake8==6.1.0
 pycodestyle==2.11.1
 pytest==7.4.3
-black==23.10.1
+black==23.11.0
 
 Flask==3.0.0
 gunicorn==21.2.0
 
-wwdtm==2.4.0
+wwdtm==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.0.0
 gunicorn==21.2.0
 
-wwdtm==2.4.0
+wwdtm==2.5.0


### PR DESCRIPTION
## Application Changes

- Replace `dateutil.parser.parse` with `datetime.datetime.strptime`

## Component Changes

- Upgrade wwdtm from 2.4.1 to 2.5.0, which drops supports for Python versions prior to 3.10 and includes:
  - Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
  - Upgrade numpy from 1.24.4 to 1.26.0

## Development Changes

- Upgrade black from 23.10.1 to 23.11.0
- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
- Bump minimum pytest version from 7.0 to 7.4 in `pyproject.toml`