### PR TITLE
Update wwdtm to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.7.0
+
+### Component Changes
+
+- Upgrade wwdtm from 2.5.0 to 2.6.0, which requires Wait Wait Stats Database version 4.4 or higher
+
 ## 2.6.1
 
 ### Application Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # graphs.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Graphs Site"""
 
-APP_VERSION = "2.6.1"
+APP_VERSION = "2.7.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ black==23.11.0
 Flask==3.0.0
 gunicorn==21.2.0
 
-wwdtm==2.5.0
+wwdtm==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.0.0
 gunicorn==21.2.0
 
-wwdtm==2.5.0
+wwdtm==2.6.0


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.5.0 to 2.6.0, which requires Wait Wait Stats Database version 4.4 or higher