### PR TITLE
Add GitHub Sponsor link support and footer rendering update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2.8.1
+
+### Application Changes
+
+- Add support for GitHub sponsorship link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.github_sponsor_url` config key
+- Change link color to match that of the Wait Wait Stats Page link color
+- Change the how render and version information is rendered on screens with a width less than 1200px to align left rather than right
+
 ## 2.8.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -56,6 +56,9 @@ def create_app():
         "mastodon_user", ""
     )
     app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
+    app.jinja_env.globals["github_sponsor_url"] = _config["settings"].get(
+        "github_sponsor_url", ""
+    )
     app.jinja_env.globals["use_latest_plotly"] = _config["settings"][
         "use_latest_plotly"
     ]

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -23,6 +23,8 @@
     .container { max-width: initial; width: 95%; }
     .dropdown-content { border: 2px solid rgba(0, 0, 0, 0.1); }
     .dropdown-content li>a, .dropdown-content li>span { color: initial; }
+    .sidenav li>a.subheader { cursor: initial; text-transform: uppercase; font-size: 0.9rem; font-weight: bold; pointer-events: none;}
+    .dropdown-content li.subheader>a { cursor: initial; text-transform: uppercase; font-size: 0.825rem; font-weight: bold; pointer-events: none;}
     .page-breadcrumb { background-color: rgba(96, 96, 96, 0.05); margin: 1.25rem 0; padding: 0.25rem 1rem; }
     .page-breadcrumb ul { list-style: none; padding: 0; }
     .page-breadcrumb ul li { display: inline; padding: 0; }
@@ -33,6 +35,9 @@
     .sidenav li>a { font-size: initial; font-weight: initial; }
     ul.footer-nav-links { list-style: none; margin: 0; padding: 0; }
     ul.footer-nav-links li { display: inline; margin: 0 0.5rem; padding: 0; }
+    #app-copyright, #app-version { display: inline-block; padding: 0.5rem 0; }
+    #app-copyright { float: left; }
+    #app-version { float: right; }
     .traceback { border: 2px solid rgba(0, 0, 0, 0.25); font-size: 90%; overflow: scroll; padding: 1.5rem; width: 100%; }
     div#ww-chart { height: 65%; height: 65vh; }
 }
@@ -46,13 +51,19 @@
     html, main, button, input, select, textarea, .collection, .collection-header, .collection-item { background-color: #202124 !important; color: white !important; }
     nav, nav ul a, .brand-logo, .page-footer, .footer-copyright, .nav-wrapper, .sidenav li>a { color: white !important; }
     nav ul a { transition: background-color 0s; }
-    nav ul.dropdown-content a:hover, .sidenav li>a:hover { background-color: rgba(240, 240, 240, 0.5); color: #323438 !important; }
+    nav ul.dropdown-content a:hover, .sidenav li>a:hover, .dropdown-content li>a:hover { background-color: rgba(240, 240, 240, 0.5); color: #323438 !important; }
     main a { color: #64b5f6 !important; }
+    .dropdown-content li.subheader:hover { background-color: inherit; font-weight: bold; }
     div.label { border-bottom: 2px solid rgba(240, 240, 240, 0.5); }
     .collection, .collection-item { border-color: rgba(240, 240, 240, 0.5) !important; }
     .collection-item a { border-bottom: 1px dotted !important; }
     .footer-copyright { background-color: #072C64 !important; }
     .sidenav, .sidenav ul, ul.dropdown-content { background-color: #323438 !important; }
+}
+
+@media only screen and (max-width: 1200px) {
+    #app-copyright, #app-version { float: none; }
+    #app-version { clear: both; display: block; }
 }
 
 @media only screen and (max-width: 720px) {
@@ -65,7 +76,6 @@
     .page-breadcrumb { font-size: 110%; line-height: 2.5rem;}
     nav .brand-logo { font-size: 1.0rem; font-weight: 500; left: 45%; transform: translateX(-40%); }
     .col.s12 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-    .footer-copyright span.right { display: block; float: initial !important; }
     div#ww-chart { height: 50%; height: 50vh; }
 }
 

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -8,8 +8,8 @@
                     <li><a href="{{ reports_url }}">Reports</a></li>
                     <li><a href="{{ stats_url }}">Stats Page</a></li>
                     <li><a href="{{ repo_url }}">GitHub</a></li>
-                    {% if patreon_url %}
-                    <li><a href="{{ patreon_url }}">Patreon</a></li>
+                    {% if github_sponsor_url or patreon_url %}
+                    <li><a href="{{ stats_url }}/about#support-stats">Support Wait Wait Stats</a></li>
                     {% endif %}
                 </ul>
             </div>
@@ -17,14 +17,16 @@
     </div>
     <div class="footer-copyright">
         <div class="container">
-            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }}
-            {% if mastodon_url and mastodon_user %}
-            <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
-            {% else %}
-            <a href="https://linhpham.org/">Linh Pham</a>.
-            {% endif %}
-            All rights reserved.
-            <span class="right">
+            <span id="app-copyright">
+                Copyright &copy; 2007&ndash;{{ current_year(time_zone) }}
+                {% if mastodon_url and mastodon_user %}
+                <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
+                {% else %}
+                <a href="https://linhpham.org/">Linh Pham</a>.
+                {% endif %}
+                All rights reserved.
+            </span>
+            <span id="app-version">
                 <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
                 <span title="Application Version">V: {{ app_version }}</span> |
                 <span title="wwdtm Version">L: {{ wwdtm_version }}</span>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -25,8 +25,15 @@
             <li><a href="{{ blog_url }}">Blog</a></li>
             <li><a href="{{ reports_url }}">Reports</a></li>
             <li><a href="{{ stats_url }}">Stats Page</a></li>
-            {% if patreon_url %}
+            {% if github_sponsor_url or patreon_url %}
+            <li class="divider" tabindex="-1"></li>
+            <li class="subheader"><a>Support Wait Wait Stats</a></li>
+                {% if github_sponsor_url %}
+            <li><a href="{{ github_sponsor_url }}">GitHub Sponsor</a></li>
+                {% endif %}
+                {% if patreon_url %}
             <li><a href="{{ patreon_url }}">Patreon</a></li>
+                {% endif %}
             {% endif %}
         </ul>
         <ul id="nav-mobile" class="right hide-on-med-and-down">
@@ -53,9 +60,15 @@
         <li><a href="{{ blog_url }}">Blog</a></li>
         <li><a href="{{ reports_url }}">Reports</a></li>
         <li><a href="{{ stats_url }}">Stats Page</a></li>
-        {% if patreon_url %}
+        {% if github_sponsor_url or patreon_url %}
         <li><div class="divider"></div></li>
+        <li><a class="subheader">Support Wait Wait Stats</a></li>
+            {% if github_sponsor_url %}
+        <li><a href="{{ github_sponsor_url }}">GitHub Sponsor</a></li>
+            {% endif %}
+            {% if patreon_url %}
         <li><a href="{{ patreon_url }}">Patreon</a></li>
+            {% endif %}
         {% endif %}
     </ul>
 </div>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "2.8.0"
+APP_VERSION = "2.8.1"

--- a/config.json.dist
+++ b/config.json.dist
@@ -24,6 +24,7 @@
         "mastodon_url": "",
         "mastodon_user": "",
         "patreon_url": "",
+        "github_sponsor_url": "",
         "use_latest_plotly": false,
         "use_decimal_scores": false
     }


### PR DESCRIPTION
## Application Changes

- Add support for GitHub sponsorship link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.github_sponsor_url` config key
- Change link color to match that of the Wait Wait Stats Page link color
- Change the how render and version information is rendered on screens with a width less than 1200px to align left rather than right