### PR TITLE
Bump flask, gunicorn, ruff and pytest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes
 
+## 2.8.3
+
+### Component Changes
+
+- Upgrade wwdtm from 2.8.0 to 2.8.2
+- Upgrade flask from 3.0.0 to 3.0.3
+- Upgrade gunicorn from 21.2.0 to 22.0.0
+
+### Development Changes
+
+- Upgrade ruff from 0.1.13 to 0.3.6
+- Upgrade pytest from 7.4.4 to 8.1.1
+
 ## 2.8.2
 
 ### Development Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,9 +67,9 @@ def create_app():
     ]
 
     # Check to see if panelistscore_decimal column exists and set a flag
-    app.config["app_settings"][
-        "has_decimal_scores_column"
-    ] = utility.panelist_decimal_score_exists(database_settings=app.config["database"])
+    app.config["app_settings"]["has_decimal_scores_column"] = (
+        utility.panelist_decimal_score_exists(database_settings=app.config["database"])
+    )
 
     # Register application blueprints
     app.register_blueprint(main_bp)

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "2.8.2"
+APP_VERSION = "2.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,40 @@ norecursedirs = [
 
 [tool.ruff]
 target-version = "py310"
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+line-length = 88 # Must agree with Black
+
+[tool.ruff.lint]
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+
 select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -39,44 +73,13 @@ select = [
     "YTT", # flake8-2020
 ]
 
-exclude = [
-    "migrations",
-    "__pycache__",
-    "manage.py",
-    "settings.py",
-    "env",
-    ".env",
-    "venv",
-    ".venv",
-]
-
-ignore = [
-    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D105",
-    "D106",
-    "D107",
-    "D200",
-    "D401",
-    "E402",
-    "E501",
-    "F401",
-    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
-    "S608",
-]
-line-length = 88 # Must agree with Black
-
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
     "D100",
     "D101",
@@ -91,5 +94,5 @@ convention = "pep257"
     "S106",   # possible hardcoded password.
 ]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-ruff==0.1.13
+ruff==0.3.6
 black==24.3.0
-pytest==7.4.4
+pytest==8.1.1
 
-Flask==3.0.0
-gunicorn==21.2.0
+Flask==3.0.3
+gunicorn==22.0.0
 
-wwdtm==2.8.0
+wwdtm==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.0.0
-gunicorn==21.2.0
+Flask==3.0.3
+gunicorn==22.0.0
 
-wwdtm==2.8.0
+wwdtm==2.8.2


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.8.0 to 2.8.2
- Upgrade flask from 3.0.0 to 3.0.3
- Upgrade gunicorn from 21.2.0 to 22.0.0

## Development Changes

- Upgrade ruff from 0.1.13 to 0.3.6
- Upgrade pytest from 7.4.4 to 8.1.1