### PR TITLE
Bump wwdtm to 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.8.4
+
+### Component Changes
+
+- Upgrade wwdtm from 2.8.2 to 2.10.0, which requires Wait Wait Stats Database version 4.7 or higher
+
 ## 2.8.3
 
 ### Component Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "2.8.3"
+APP_VERSION = "2.8.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ pytest==8.1.1
 Flask==3.0.3
 gunicorn==22.0.0
 
-wwdtm==2.8.2
+wwdtm==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.0.3
 gunicorn==22.0.0
 
-wwdtm==2.8.2
+wwdtm==2.10.0


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.8.2 to 2.10.0, which requires Wait Wait Stats Database version 4.7 or higher