### PR TITLE
Adding Umami analytics support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Ruff
+.ruff_cache
+
 # C extensions
 *.so
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 2.10.0
+
+### Application Changes
+
+- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:
+
+| Config Key | Description |
+| ---------- | ----------- |
+| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
+| `url` | URL of the Umami analytics script |
+| `data_website_id` | Umami Site ID |
+| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
+| `data_host_url` | Override the location where Umami data is sent to |
+| `data_domains` | Comma-delimited list of domains where the Umami script should be active |
+
 ## 2.9.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,8 +16,11 @@ from app.shows.routes import blueprint as shows_bp
 from app.sitemaps.routes import blueprint as sitemaps_bp
 from app.version import APP_VERSION
 
+from .utility import format_umami_analytics
+
 
 def create_app():
+    """Create Flask application."""
     app = Flask(__name__)
     app.url_map.strict_slashes = False
 
@@ -44,6 +47,10 @@ def create_app():
     app.jinja_env.globals["time_zone"] = app.config["app_settings"]["time_zone"]
     app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
         "ga_property_code", ""
+    )
+    umami = _config["settings"].get("umami_analytics", None)
+    app.jinja_env.globals["umami_analytics"] = format_umami_analytics(
+        umami_analytics=umami
     )
     app.jinja_env.globals["api_url"] = _config["settings"].get("api_url", "")
     app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,11 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+
+    {% if umami_analytics %}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {% endif %}
 </head>
 <body>
 {% include "core/nav.html" %}

--- a/app/templates/errors/base.html
+++ b/app/templates/errors/base.html
@@ -14,6 +14,11 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+
+    {%- if umami_analytics -%}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {%- endif -%}
 </head>
 <body>
 <main>

--- a/app/utility.py
+++ b/app/utility.py
@@ -29,6 +29,33 @@ month_names = {
 }
 
 
+def format_umami_analytics(umami_analytics: dict = None) -> str:
+    """Return formatted string for Umami Analytics."""
+    if not umami_analytics:
+        return None
+
+    _enabled = bool(umami_analytics.get("_enabled", False))
+
+    if not _enabled:
+        return None
+
+    url = umami_analytics.get("url")
+    website_id = umami_analytics.get("data_website_id")
+    auto_track = bool(umami_analytics.get("data_auto_track", True))
+    host_url = umami_analytics.get("data_host_url")
+    domains = umami_analytics.get("data_domains")
+
+    if url and website_id:
+        host_url_prop = f'data-host-url="{host_url}"' if host_url else ""
+        auto_track_prop = f'data-auto-track="{str(auto_track).lower()}"'
+        domains_prop = f'data-domains="{domains}"' if domains else ""
+
+        props = " ".join([host_url_prop, auto_track_prop, domains_prop])
+        return f'<script defer src="{url}" data-website-id="{website_id}" {props.strip()}></script>'
+
+    return None
+
+
 def current_year(time_zone: str = "UTC") -> str:
     """Return the current year."""
     _time_zone = pytz.timezone(time_zone)

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "2.9.0"
+APP_VERSION = "2.10.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -16,6 +16,14 @@
         "api_url": "",
         "blog_url": "",
         "ga_property_code": null,
+        "umami_analytics": {
+            "_enabled": false,
+            "url": "",
+            "data_website_id": "",
+            "data_domains": "",
+            "data_host_url": "",
+            "data_auto_track": true
+        },
         "graphs_url": "",
         "repo_url": "https://github.com/questionlp/graphs.wwdt.me_v2",
         "reports_url": "",


### PR DESCRIPTION
## Application Changes

- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:

| Config Key | Description |
| ---------- | ----------- |
| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
| `url` | URL of the Umami analytics script |
| `data_website_id` | Umami Site ID |
| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
| `data_host_url` | Override the location where Umami data is sent to |
| `data_domains` | Comma-delimited list of domains where the Umami script should be active |