### PR TITLE
Relocate Bootstrap and app JS, corrected Umami include in error page …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 3.3.5
+
+### Application Changes
+
+- Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
+- Corrected Umami Analytics include for error page template
+- Update Bootstrap icon classes to include `.bi`
+
+### Component Changes
+
+- Set Jinja2 version to `~=3.1.6`
+
 ## 3.3.4
 
 ### Application Changes

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <title>{% block title %}{% endblock %} | Wait Wait Don't Tell Me! Graphs</title>
     {% include "core/head.html" with context %}
+    {% include "core/init_js.html" %}
 </head>
 <body class="d-flex flex-column h-100">
 {% include "core/nav.html" %}
@@ -14,7 +15,5 @@
 </main>
 
 {% include "core/footer.html" %}
-
-{% include "core/init_js.html" %}
 </body>
 </html>

--- a/app/templates/core/init_js.html
+++ b/app/templates/core/init_js.html
@@ -1,3 +1,2 @@
-<!--JavaScript at end of body for optimized loading-->
-<script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/app-code.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/app-code.js') }}"></script>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -7,7 +7,7 @@
         <div class="container-fluid">
             <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar"
                 aria-controls="offcanvasNavbar" aria-expanded="false" aria-label="Toggle navigation">
-                <i class="bi-list"></i>
+                <i class="bi bi-list"></i>
             </button>
             <h1><a class="navbar-brand" href="{{ url_for('main.index') }}">Wait Wait Graphs</a></h1>
 
@@ -60,7 +60,7 @@
                             <button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center"
                                 id="bd-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown"
                                 data-bs-display="static" aria-label="Toggle Theme (Auto)">
-                                <i class="bi-circle-half"></i>
+                                <i class="bi bi-circle-half"></i>
                                 <span class="d-md-none" id="bd-theme-text">Toggle theme</span>
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end" id="theme-dropdown"
@@ -68,21 +68,21 @@
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center"
                                         data-bs-theme-value="light" aria-pressed="false">
-                                        <i class="bi-sun-fill"></i>
+                                        <i class="bi bi-sun-fill"></i>
                                         Light
                                     </button>
                                 </li>
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center"
                                         data-bs-theme-value="dark" aria-pressed="false">
-                                        <i class="bi-moon-stars-fill"></i>
+                                        <i class="bi bi-moon-stars-fill"></i>
                                         Dark
                                     </button>
                                 </li>
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center active"
                                         data-bs-theme-value="auto" aria-pressed="true">
-                                        <i class="bi-circle-half"></i>
+                                        <i class="bi bi-circle-half"></i>
                                         Auto
                                     </button>
                                 </li>

--- a/app/templates/errors/base.html
+++ b/app/templates/errors/base.html
@@ -15,9 +15,8 @@
     </script>
     {% endif %}
 
-    {% if umami_analytics %}
-    <!-- Umami Analytics -->
-    {{ umami_analytics | safe }}
+    {%- if umami %}
+    {% include "core/umami.html" %}
     {% endif %}
 </head>
 <body>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest==8.3.3
 pytest-cov==5.0.0
 
 Flask==3.1.0
+Jinja2~=3.1.6
 gunicorn==23.0.0
 
 wwdtm==2.17.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==3.1.0
+Jinja2~=3.1.6
 gunicorn==23.0.0
 
 wwdtm==2.17.2


### PR DESCRIPTION
## Application Changes

- Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
- Corrected Umami Analytics include for error page template
- Update Bootstrap icon classes to include `.bi`

## Component Changes

- Set Jinja2 version to `~=3.1.6`