### PR TITLE
Update graph title placement, y-axis updates, update light/dark mode handling for graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Changed the y-axis to show the axis line, which is the same behavior as the x-axis
 - Changed the y-axis tick counts for most graphs to reduce the number of ticks, thus reducing graph clutter
 - Removed graph legends on graphs with only one data category
-- Updated light and dark mode detection at graph rendering to use both the CSS `prefers-color-scheme` value as well as the local storage `theme` value. A page refresh is still required to get the correct color scheme to be applied
+- Updated light and dark mode detection at graph rendering to use both the `prefers-color-scheme` value as well as the local storage `theme` value. A page refresh is still required to get the correct color scheme to be applied
+  - Note: The `theme` value that is selected from the dropdown will take precedence over the `prefers-color-scheme`. If the `theme` value is not set (default) or set to `auto`, then the `prefers-color-scheme` value is honored
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removed graph legends on graphs with only one data category
 - Updated light and dark mode detection at graph rendering to use both the `prefers-color-scheme` value as well as the local storage `theme` value. A page refresh is still required to get the correct color scheme to be applied
   - Note: The `theme` value that is selected from the dropdown will take precedence over the `prefers-color-scheme`. If the `theme` value is not set (default) or set to `auto`, then the `prefers-color-scheme` value is honored
+  - There may be some cases where there is a mismatch between the graph color mode and the page color mode. Switching between themes and refreshing the page should cause the local storage value to be picked up properly
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 3.5.1
+
+### Application Changes
+
+- Changed the graph titles to be left aligned rather than center aligned
+- Changed the top padding for graph titles to be inset by 6 pixels
+- Changed the y-axis to show the axis line, which is the same behavior as the x-axis
+- Changed the y-axis tick counts for most graphs to reduce the number of ticks, thus reducing graph clutter
+- Removed graph legends on graphs with only one data category
+- Updated light and dark mode detection at graph rendering to use both the CSS `prefers-color-scheme` value as well as the local storage `theme` value. A page refresh is still required to get the correct color scheme to be applied
+
 ## 3.5.0
 
 ### Application Changes

--- a/app/locations/templates/locations/home-vs-away/graph.html
+++ b/app/locations/templates/locations/home-vs-away/graph.html
@@ -29,12 +29,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/locations/templates/locations/home-vs-away/graph.html
+++ b/app/locations/templates/locations/home-vs-away/graph.html
@@ -30,7 +30,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -91,11 +93,16 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -114,9 +121,10 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 5,
+            dtick: 10,
             fixedrange: true,
-            range: [0, 60],
+            range: [0, 55],
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/panelists/templates/panelists/aggregate-scores/graph.html
+++ b/app/panelists/templates/panelists/aggregate-scores/graph.html
@@ -30,7 +30,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40
@@ -58,16 +60,6 @@
             },
         },
         hovermode: "x",
-        legend: {
-            font: {
-                color: axisColor,
-                family: fontList,
-                size: 16
-            },
-            orientation: "h",
-            y: 1.025,
-            x: 0,
-        },
         margin: {
             l: 60,
             r: 40,
@@ -76,12 +68,18 @@
         },
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
+        showlegend: false,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -100,7 +98,9 @@
         },
         yaxis: {
             color: axisColor,
+            dtick: 100,
             fixedrange: true,
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/panelists/templates/panelists/aggregate-scores/graph.html
+++ b/app/panelists/templates/panelists/aggregate-scores/graph.html
@@ -29,10 +29,12 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40

--- a/app/panelists/templates/panelists/appearances-by-year/details.html
+++ b/app/panelists/templates/panelists/appearances-by-year/details.html
@@ -32,10 +32,12 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40

--- a/app/panelists/templates/panelists/appearances-by-year/details.html
+++ b/app/panelists/templates/panelists/appearances-by-year/details.html
@@ -33,7 +33,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40
@@ -41,11 +43,15 @@
     }
 
     // Set y-axis dtick value
-    let yAxisdTick = 2;
+    let yAxisdTick = 1;
     let appearanceCounts = {{ count | safe }};
     let maxCount = Math.max.apply(Math, appearanceCounts);
-    if (maxCount <= 3) {
-        yAxisdTick = 1;
+    if (maxCount >= 50) {
+        yAxisdTick = 10;
+    } else if (maxCount >= 15) {
+        yAxisdTick = 5;
+    } else if (maxCount >= 5) {
+        yAxisdTick = 2;
     }
 
     let data = [
@@ -69,16 +75,6 @@
             },
         },
         hovermode: "x",
-        legend: {
-            font: {
-                color: axisColor,
-                family: fontList,
-                size: 16
-            },
-            orientation: "h",
-            y: 1.025,
-            x: 0,
-        },
         margin: {
             l: 60,
             r: 40,
@@ -87,12 +83,18 @@
         },
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
+        showlegend: false,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: {{ info.name | safe }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ info.name | safe }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -113,6 +115,7 @@
             dtick: yAxisdTick,
             color: axisColor,
             fixedrange: true,
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/panelists/templates/panelists/score-breakdown/details.html
+++ b/app/panelists/templates/panelists/score-breakdown/details.html
@@ -34,7 +34,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40
@@ -42,11 +44,15 @@
     }
 
     // Set y-axis dtick value
-    let yAxisdTick = 2;
+    let yAxisdTick = 1;
     let scoreCounts = {{ scores.count | safe }};
     let maxCount = Math.max.apply(Math, scoreCounts);
-    if (maxCount <= 3) {
-        yAxisdTick = 1;
+    if (maxCount >= 50) {
+        yAxisdTick = 10;
+    } else if (maxCount >= 15) {
+        yAxisdTick = 5;
+    } else if (maxCount >= 5) {
+        yAxisdTick = 2;
     }
 
     let data = [
@@ -69,16 +75,6 @@
             },
         },
         hovermode: "x",
-        legend: {
-            font: {
-                color: axisColor,
-                family: fontList,
-                size: 15
-            },
-            orientation: "h",
-            y: 1.025,
-            x: 0,
-        },
         margin: {
             l: 60,
             r: 60,
@@ -88,12 +84,18 @@
         showlegend: true,
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
+        showlegend: false,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: {{ info.name | safe }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ info.name | safe }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -113,6 +115,7 @@
             color: axisColor,
             dtick: yAxisdTick,
             fixedrange: true,
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/panelists/templates/panelists/score-breakdown/details.html
+++ b/app/panelists/templates/panelists/score-breakdown/details.html
@@ -33,10 +33,12 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40

--- a/app/panelists/templates/panelists/scores-by-appearance/details.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/details.html
@@ -32,10 +32,12 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40

--- a/app/panelists/templates/panelists/scores-by-appearance/details.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/details.html
@@ -33,7 +33,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         markerColor = "#78a9ff"; // IBM Blue 40
@@ -61,16 +63,6 @@
             },
         },
         hovermode: "x",
-        legend: {
-            font: {
-                color: axisColor,
-                family: fontList,
-                size: 16
-            },
-            orientation: "h",
-            y: 1.025,
-            x: 0,
-        },
         margin: {
             l: 60,
             r: 40,
@@ -79,12 +71,18 @@
         },
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
+        showlegend: false,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: {{ info.name | safe }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ info.name | safe }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -104,10 +102,11 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 2,
+            dtick: 5,
             fixedrange: true,
+            showline: true,
             tickfont: { size: 16 },
-            range: [0, 28],
+            range: [0, 30],
             title: {
                 font: { size: 18 },
                 text: "Score"

--- a/app/shows/templates/shows/all-scores/details.html
+++ b/app/shows/templates/shows/all-scores/details.html
@@ -30,12 +30,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/shows/templates/shows/all-scores/details.html
+++ b/app/shows/templates/shows/all-scores/details.html
@@ -31,7 +31,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -91,11 +93,16 @@
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: {{ year }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ year }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -115,8 +122,9 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 5,
+            dtick: 10,
             fixedrange: true,
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/bluff-counts/all.html
+++ b/app/shows/templates/shows/bluff-counts/all.html
@@ -32,7 +32,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -90,11 +92,16 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: All Years"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: All Years",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -114,9 +121,10 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 1,
+            dtick: 5,
             fixedrange: true,
-            range: [0, max_height],
+            range: [0, max_height + 2],
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/bluff-counts/all.html
+++ b/app/shows/templates/shows/bluff-counts/all.html
@@ -31,12 +31,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/shows/templates/shows/bluff-counts/details.html
+++ b/app/shows/templates/shows/bluff-counts/details.html
@@ -31,7 +31,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -83,17 +85,22 @@
             l: 60,
             r: 40,
             t: 48,
-            b: 90
+            b: 90,
         },
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: {{ year }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ year }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -112,9 +119,10 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 1,
+            dtick: 3,
             fixedrange: true,
-            range: [0, max_height],
+            range: [0, max_height + 1],
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/bluff-counts/details.html
+++ b/app/shows/templates/shows/bluff-counts/details.html
@@ -30,12 +30,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/shows/templates/shows/counts-by-day-month/all.html
+++ b/app/shows/templates/shows/counts-by-day-month/all.html
@@ -39,7 +39,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -117,11 +119,16 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: All Months"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: All Months",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -143,6 +150,8 @@
             color: axisColor,
             dtick: 1,
             fixedrange: true,
+            showline: true,
+            range: [0, 4.5],
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/counts-by-day-month/all.html
+++ b/app/shows/templates/shows/counts-by-day-month/all.html
@@ -38,12 +38,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/shows/templates/shows/counts-by-day-month/details.html
+++ b/app/shows/templates/shows/counts-by-day-month/details.html
@@ -32,7 +32,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -104,11 +106,16 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}: {{ month }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ month }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -128,6 +135,8 @@
             color: axisColor,
             dtick: 1,
             fixedrange: true,
+            showline: true,
+            range: [0, 4.5],
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/counts-by-day-month/details.html
+++ b/app/shows/templates/shows/counts-by-day-month/details.html
@@ -31,12 +31,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/shows/templates/shows/counts-by-year/graph.html
+++ b/app/shows/templates/shows/counts-by-year/graph.html
@@ -35,7 +35,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -102,11 +104,16 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -125,9 +132,10 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 5,
+            dtick: 10,
             fixedrange: true,
-            range: [0, 60],
+            range: [0, 56],
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/counts-by-year/graph.html
+++ b/app/shows/templates/shows/counts-by-year/graph.html
@@ -34,12 +34,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
@@ -30,7 +30,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
     }
@@ -64,15 +66,6 @@
                     size: 16
                 }
             },
-            /*
-            colorscale: [
-                [0, "#000"],
-                [0.4, "#ff832b"],   // IBM Alert 40
-                [0.6, "#f1c21b"],   // IBM Alert 30
-                [1, "#f4f4f4"]      // IBM Gray 10
-                
-            ],
-            */
             colorscale: colorscale,
             hoverongaps: false,
             hovertemplate: "Year: %{y}<br>Month: %{x}<br>Aggregate Score: %{z}<extra></extra>",
@@ -99,14 +92,20 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
+            showline: true,
             tickfont: { size: 14 },
             title: {
                 font: { size: 18 },
@@ -115,6 +114,7 @@
         },
         yaxis: {
             color: axisColor,
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
@@ -29,12 +29,16 @@
     let colorscale = {{ colorscale | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
+        colorway = {{ colorway_dark | safe }};
     }
 
     let months = [

--- a/app/shows/templates/shows/monthly-average-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-average-score-heatmap/graph.html
@@ -30,7 +30,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
     }
@@ -64,15 +66,6 @@
                     size: 16
                 }
             },
-            /*
-            colorscale: [
-                [0, "#000"],
-                [0.5, "#a2191f"],   // IBM Red 70
-                [0.625, "#ff832b"], // IBM Alert 40
-                [0.75, "#f1c21b"],  // IBM Alert 30
-                [1, "#f4f4f4"]      // IBM Gray 10
-            ],
-            */
             colorscale: colorscale,
             hoverongaps: false,
             hovertemplate: "Year: %{y}<br>Month: %{x}<br>Average Score: %{z}<extra></extra>",
@@ -101,14 +94,20 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
+            showline: true,
             tickfont: { size: 14 },
             title: {
                 font: { size: 18 },
@@ -117,6 +116,7 @@
         },
         yaxis: {
             color: axisColor,
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/monthly-average-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-average-score-heatmap/graph.html
@@ -29,12 +29,16 @@
     let colorscale = {{ colorscale_bold | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
+        colorway = {{ colorway_dark | safe }};
     }
 
     let months = [

--- a/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
+++ b/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
@@ -43,7 +43,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -107,11 +109,16 @@
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -130,9 +137,10 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 10,
+            dtick: 20,
             fixedrange: true,
-            range: [0, 100.5],
+            range: [0, 105],
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
+++ b/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
@@ -42,15 +42,16 @@
     let bluffHoverColor = "#fff";
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
-        notMyJobHoverColor = "#161616"; // IBM Gray 100
-        bluffHoverColor = "#fff";
     }
 
     // Set y-axis dtick value

--- a/app/shows/templates/shows/panel-gender-mix/graph.html
+++ b/app/shows/templates/shows/panel-gender-mix/graph.html
@@ -29,7 +29,9 @@
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
         colorway = {{ colorway_dark | safe }};
@@ -96,11 +98,16 @@
         plot_bgcolor: backgroundColor,
         showlegend: true,
         title: {
+            automargin: true,
             font: {
                 color: axisColor,
                 size: 20
             },
-            text: "{{ page_title }}"
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
         },
         xaxis: {
             color: axisColor,
@@ -119,9 +126,10 @@
         },
         yaxis: {
             color: axisColor,
-            dtick: 5,
+            dtick: 10,
             fixedrange: true,
-            range: [0, 60],
+            range: [0, 56],
+            showline: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },

--- a/app/shows/templates/shows/panel-gender-mix/graph.html
+++ b/app/shows/templates/shows/panel-gender-mix/graph.html
@@ -28,12 +28,15 @@
     let colorway = {{ colorway_light | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
-    // Change colors if in dark mode
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
     const getStoredTheme = () => localStorage.getItem("theme");
     const storedTheme = getStoredTheme();
-    if ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) && (storedTheme === "dark" || storedTheme === "auto")) {
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    if (darkMode) {
         axisColor = "#fff";
         backgroundColor = "#161616"; // IBM Gray 100
+        markerColor = "#78a9ff"; // IBM Blue 40
         colorway = {{ colorway_dark | safe }};
     }
 

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.5.0"
+APP_VERSION = "3.5.1"


### PR DESCRIPTION
## Application Changes

- Changed the graph titles to be left aligned rather than center aligned
- Changed the top padding for graph titles to be inset by 6 pixels
- Changed the y-axis to show the axis line, which is the same behavior as the x-axis
- Changed the y-axis tick counts for most graphs to reduce the number of ticks, thus reducing graph clutter
- Removed graph legends on graphs with only one data category
- Updated light and dark mode detection at graph rendering to use both the `prefers-color-scheme` value as well as the local storage `theme` value. A page refresh is still required to get the correct color scheme to be applied
  - Note: The `theme` value that is selected from the dropdown will take precedence over the `prefers-color-scheme`. If the `theme` value is not set (default) or set to `auto`, then the `prefers-color-scheme` value is honored
  - There may be some cases where there is a mismatch between the graph color mode and the page color mode. Switching between themes and refreshing the page should cause the local storage value to be picked up properly