### PR TITLE
Enable scroll zooming on three graphs, standardize Plotly mode bar buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Application Changes
 
-- Enable scroll zooming for the Panelists "Scores by Appearance" and Shows "Counts by Day of Month: All" graphs
+- Enable scroll zooming for the following graphs:
+  - Panelists "Scores by Appearance"
+  - Shows "Bluff the Listener Counts: All Years"
+  - Shows "Counts by Day of Month: All"
+- Standardize Plotly mode bar buttons that are shows across all graphs
 
 ## 3.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 3.6.2
+
+### Application Changes
+
+- Enable scroll zooming for the Panelists "Scores by Appearance" and Shows "Counts by Day of Month: All" graphs
+
 ## 3.6.1
 
 ### Application Changes

--- a/app/locations/templates/locations/home-vs-away/graph.html
+++ b/app/locations/templates/locations/home-vs-away/graph.html
@@ -144,8 +144,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/panelists/templates/panelists/aggregate-scores/graph.html
+++ b/app/panelists/templates/panelists/aggregate-scores/graph.html
@@ -119,8 +119,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/panelists/templates/panelists/appearances-by-year/details.html
+++ b/app/panelists/templates/panelists/appearances-by-year/details.html
@@ -134,8 +134,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/panelists/templates/panelists/score-breakdown/details.html
+++ b/app/panelists/templates/panelists/score-breakdown/details.html
@@ -134,8 +134,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/panelists/templates/panelists/scores-by-appearance/details.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/details.html
@@ -124,8 +124,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         scrollZoom: true,

--- a/app/panelists/templates/panelists/scores-by-appearance/details.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/details.html
@@ -128,6 +128,7 @@
             "zoomOut2d"
         ],
         responsive: true,
+        scrollZoom: true,
         toImageButtonOptions: {
             filename: "scores-by-appearance-{{ info.slug }}",
             height: 800,

--- a/app/shows/templates/shows/all-scores/details.html
+++ b/app/shows/templates/shows/all-scores/details.html
@@ -144,8 +144,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/bluff-counts/all.html
+++ b/app/shows/templates/shows/bluff-counts/all.html
@@ -144,10 +144,12 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
+        scrollZoom: true,
         toImageButtonOptions: {
             filename: "bluff-counts-year-month",
             height: 800,

--- a/app/shows/templates/shows/bluff-counts/details.html
+++ b/app/shows/templates/shows/bluff-counts/details.html
@@ -142,8 +142,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/counts-by-day-month/all.html
+++ b/app/shows/templates/shows/counts-by-day-month/all.html
@@ -92,7 +92,7 @@
         autosize: true,
         barmode: "stack",
         colorway: colorway,
-        dragmode: "pan",
+        // dragmode: "pan",
         font: { family: fontList },
         hoverlabel: {
             font: {
@@ -170,10 +170,11 @@
             "autoScale2d",
             "lasso2d",
             "select2d",
-            "zoomIn2d",
-            "zoomOut2d"
+            // "zoomIn2d",
+            // "zoomOut2d"
         ],
         responsive: true,
+        scrollZoom: true,
         toImageButtonOptions: {
             filename: "counts-by-day-months-all",
             height: 800,

--- a/app/shows/templates/shows/counts-by-day-month/all.html
+++ b/app/shows/templates/shows/counts-by-day-month/all.html
@@ -170,8 +170,6 @@
             "autoScale2d",
             "lasso2d",
             "select2d",
-            // "zoomIn2d",
-            // "zoomOut2d"
         ],
         responsive: true,
         scrollZoom: true,

--- a/app/shows/templates/shows/counts-by-day-month/details.html
+++ b/app/shows/templates/shows/counts-by-day-month/details.html
@@ -156,8 +156,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/counts-by-year/graph.html
+++ b/app/shows/templates/shows/counts-by-year/graph.html
@@ -155,8 +155,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
@@ -134,8 +134,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/monthly-average-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-average-score-heatmap/graph.html
@@ -136,8 +136,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
+++ b/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
@@ -158,8 +158,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/shows/templates/shows/panel-gender-mix/graph.html
+++ b/app/shows/templates/shows/panel-gender-mix/graph.html
@@ -149,8 +149,9 @@
     let config = {
         displaylogo: false,
         modeBarButtonsToRemove: [
-            "zoomIn2d",
-            "zoomOut2d"
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
         ],
         responsive: true,
         toImageButtonOptions: {

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.6.1"
+APP_VERSION = "3.6.2"


### PR DESCRIPTION
## Application Changes

- Enable scroll zooming for the following graphs:
  - Panelists "Scores by Appearance"
  - Shows "Bluff the Listener Counts: All Years"
  - Shows "Counts by Day of Month: All"
- Standardize Plotly mode bar buttons that are shows across all graphs