### PR TITLE
Update page and graph descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 3.6.5
+
+### Application Changes
+
+- Updated wording of the following page and graph descriptions to clarify that appearances are only for regular shows:
+  - Panelist Appearances by Year
+  - Panelist Scores by Appearance
+
 ## 3.6.4
 
 ### Application Changes

--- a/app/panelists/templates/panelists/appearances-by-year/details.html
+++ b/app/panelists/templates/panelists/appearances-by-year/details.html
@@ -17,7 +17,8 @@
 <p>
     This chart displays the number of times
     <a href="{{ stats_url }}/panelists/{{ info.slug }}">{{ info.name }}</a>
-    has made an appearance on the show, broken down by year.
+    has made an appearance on regular shows broken down by year. Regular shows
+    do not include Best Of, repeat and repeat Best Of shows.
 </p>
 
 <div class="info py-2">

--- a/app/panelists/templates/panelists/appearances-by-year/index.html
+++ b/app/panelists/templates/panelists/appearances-by-year/index.html
@@ -13,7 +13,8 @@
 <h2>{{ page_title }}</h2>
 <p>
     Choose from one of the panelists below to view a chart displaying
-    the number of appearances broken down by year.
+    the number of appearances on regular shows broken down by year. Regular
+    shows do not include Best Of, repeat and repeat Best Of shows.
 </p>
 
 <div class="info">

--- a/app/panelists/templates/panelists/scores-by-appearance/details.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/details.html
@@ -17,7 +17,8 @@
 <p>
     This chart displays scores for all of
     <a href="{{ stats_url }}/panelists/{{ info.slug }}">{{ info.name }}'s</a>
-    appearances, excluding Best Of and repeat shows.
+    reguar show appearances. Regular shows exclude Best Of, repeat and repeat
+    Best Of shows.
 </p>
 
 <div class="info py-2">

--- a/app/panelists/templates/panelists/scores-by-appearance/index.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/index.html
@@ -13,8 +13,8 @@
 <h2>{{ page_title }}</h2>
 <p>
     Choose from one of the panelists below to view a chart displaying
-    their scores for each of their appearances (excluding Best Of and repeat
-    shows).
+    their scores for each of their appearances on regular shows. Regular shows
+    excludes Best Of, repeat and repeat Best Of shows.
 </p>
 
 <div class="info">

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.6.4"
+APP_VERSION = "3.6.5"


### PR DESCRIPTION
## Application Changes

- Updated wording of the following page and graph descriptions to clarify that appearances are only for regular shows:
  - Panelist Appearances by Year
  - Panelist Scores by Appearance