### PR TITLE
Add new location heatmaps, fix Bluff the Listener queries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ charset = utf-8
 [*.{css,html,json,py,rst,tmpl}]
 indent_size = 4
 indent_style = space
+
+[sitemap.xml]
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 3.9.0
+
+### Application Changes
+
+- Added four new heatmaps that plot shows that were recorded at home (in Chicago, Illinois), away from Chicago, and shows recorded from home/remote studios. The fourth heatmap overlays all three location types in one heatmap.
+  - Hovering over each block in the heatmap only displays the year and the show number for that year
+- Added a new set of colorscales for the new location heatmaps that use a different set of colors from the other colorscales due to the need to make each one distinct from each other when mixed in with other colors. The colors were chosen to ensure that they are distinct for those with color blindness.
+
 ## 3.8.3
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - Added four new heatmaps that plot shows that were recorded at home (in Chicago, Illinois), away from Chicago, and shows recorded from home/remote studios. The fourth heatmap overlays all three location types in one heatmap.
   - Hovering over each block in the heatmap only displays the year and the show number for that year
-- Added a new set of colorscales for the new location heatmaps that use a different set of colors from the other colorscales due to the need to make each one distinct from each other when mixed in with other colors. The colors were chosen to ensure that they are distinct for those with color blindness.
+- Added a new Locations "Show Location Types by Year" chart that plots out the location type (home, remote, home/remote studios) for each show for a given year
+- Added a new set of colorscales for the new location heatmaps that use a different set of colors from the other colorscales due to the need to make each one distinct from each other when mixed in with other colors. The colors were chosen to ensure that they are distinct and have enough contrast for people with forms of visual impairments
+- Changed hover format for line and bar charts to use a unified hover box to combine multiple x-axis values to make it easier to read
 
 ## 3.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Changed hover format for line and bar charts to use a unified hover box to combine multiple x-axis values to make it easier to read
 - Fixed the Bluff the Listener database queries for the "Not My Job vs Bluff the Listener Win Ratios" chart that had incorrect filters causing additional data to be included and counted for
 
+### Component Updates
+
+- Upgraded Plotly.js from 3.3.0 to 3.3.1
+
 ## 3.8.3
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 - Added four new heatmaps that plot shows that were recorded at home (in Chicago, Illinois), away from Chicago, and shows recorded from home/remote studios. The fourth heatmap overlays all three location types in one heatmap.
   - Hovering over each block in the heatmap only displays the year and the show number for that year
+  - Displaying the show date instead of the show number of a given year leads to issues with the heatmap due to dates not aligning correct and issues with rendering the axis
 - Added a new Locations "Show Location Types by Year" chart that plots out the location type (home, remote, home/remote studios) for each show for a given year
 - Added a new set of colorscales for the new location heatmaps that use a different set of colors from the other colorscales due to the need to make each one distinct from each other when mixed in with other colors. The colors were chosen to ensure that they are distinct and have enough contrast for people with forms of visual impairments
 - Changed hover format for line and bar charts to use a unified hover box to combine multiple x-axis values to make it easier to read
+- Fixed the Bluff the Listener database queries for the "Not My Job vs Bluff the Listener Win Ratios" chart that had incorrect filters causing additional data to be included and counted for
 
 ## 3.8.3
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,6 +90,26 @@ def create_app():
     app.jinja_env.globals["colorscale_compressed_bottom_retro"] = json.dumps(
         _colors["colorscale_compressed_bottom_retro"]
     )
+    app.jinja_env.globals["colorscale_home"] = json.dumps(_colors["colorscale_home"])
+    app.jinja_env.globals["colorscale_home_retro"] = json.dumps(
+        _colors["colorscale_home_retro"]
+    )
+    app.jinja_env.globals["colorscale_away"] = json.dumps(_colors["colorscale_away"])
+    app.jinja_env.globals["colorscale_away_retro"] = json.dumps(
+        _colors["colorscale_away_retro"]
+    )
+    app.jinja_env.globals["colorscale_studios"] = json.dumps(
+        _colors["colorscale_studios"]
+    )
+    app.jinja_env.globals["colorscale_studios_retro"] = json.dumps(
+        _colors["colorscale_studios_retro"]
+    )
+    app.jinja_env.globals["colorscale_home_away_studios"] = json.dumps(
+        _colors["colorscale_home_away_studios"]
+    )
+    app.jinja_env.globals["colorscale_home_away_studios_retro"] = json.dumps(
+        _colors["colorscale_home_away_studios_retro"]
+    )
     app.jinja_env.globals["colorscale_retro"] = json.dumps(_colors["colorscale_retro"])
     app.jinja_env.globals["colorway_light"] = json.dumps(_colors["colorway_light"])
     app.jinja_env.globals["colorway_dark"] = json.dumps(_colors["colorway_dark"])

--- a/app/config.py
+++ b/app/config.py
@@ -73,6 +73,48 @@ COLORSCALE_RETRO: list[float | str] = [
     [1.0, "#ffccff"],
 ]
 
+COLORSCALE_HOME: list[float | str] = [
+    [0.0, "#000000"],  # Black
+    [1.0, "#a56eff"],  # IBM Purple 50
+]
+
+COLORSCALE_HOME_RETRO: list[float | str] = [
+    [0.0, "#000000"],  # Black
+    [1.0, "#ff66ff"],
+]
+
+COLORSCALE_AWAY: list[float | str] = [
+    [0.0, "#000000"],  # Black
+    [1.0, "#f1c21b"],  # IBM Alert 30
+]
+
+COLORSCALE_AWAY_RETRO: list[float | str] = [
+    [0.0, "#000000"],  # Black
+    [1.0, "#ffff66"],
+]
+
+COLORSCALE_STUDIOS: list[float | str] = [
+    [0.0, "#000000"],  # Black
+    [1.0, "#007d79"],  # IBM Teal 60
+]
+
+COLORSCALE_STUDIOS_RETRO: list[float | str] = [
+    [0.0, "#000000"],  # Black
+    [1.0, "#00cc00"],
+]
+
+COLORSCALE_HOME_AWAY_STUDIOS: list[float | str] = [
+    [0.0, "#f1c21b"],  # IBM Alert 30 (Away)
+    [0.5, "#a56eff"],  # IBM Purple 50 (Home)
+    [1.0, "#007d79"],  # IBM Teal 60 (Home/Remote Studios)
+]
+
+COLORSCALE_HOME_AWAY_STUDIOS_RETRO: list[float | str] = [
+    [0.0, "#ffff66"],  # Away
+    [0.5, "#ff66ff"],  # Home
+    [1.0, "#00cc00"],  # Home/Remote Studios
+]
+
 
 def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
     """Read colors YAML configuration file."""
@@ -96,6 +138,26 @@ def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
                 "colorscale_compressed_bottom_retro", COLORSCALE_COMPRESSED_BOTTOM_RETRO
             ),
             "colorscale_retro": colors_config.get("colorscale_retro", COLORSCALE_RETRO),
+            "colorscale_home": colors_config.get("colorscale_home", COLORSCALE_HOME),
+            "colorscale_home_retro": colors_config.get(
+                "colorscale_home_retro", COLORSCALE_HOME_RETRO
+            ),
+            "colorscale_away": colors_config.get("colorscale_away", COLORSCALE_AWAY),
+            "colorscale_away_retro": colors_config.get(
+                "colorscale_away_retro", COLORSCALE_AWAY_RETRO
+            ),
+            "colorscale_studios": colors_config.get(
+                "colorscale_studios", COLORSCALE_STUDIOS
+            ),
+            "colorscale_studios_retro": colors_config.get(
+                "colorscale_studios_retro", COLORSCALE_STUDIOS_RETRO
+            ),
+            "colorscale_home_away_studios": colors_config.get(
+                "colorscale_home_away_studios", COLORSCALE_HOME_AWAY_STUDIOS
+            ),
+            "colorscale_home_away_studios_retro": colors_config.get(
+                "colorscale_home_away_studios_retro", COLORSCALE_HOME_AWAY_STUDIOS_RETRO
+            ),
         }
     else:
         _config = {
@@ -107,6 +169,14 @@ def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
             "colorscale_compressed_bottom": COLORSCALE_COMPRESSED_BOTTOM,
             "colorscale_compressed_bottom_retro": COLORSCALE_COMPRESSED_BOTTOM_RETRO,
             "colorscale_retro": COLORSCALE_RETRO,
+            "colorscale_home": COLORSCALE_HOME,
+            "colorscale_home_retro": COLORSCALE_HOME_RETRO,
+            "colorscale_away": COLORSCALE_AWAY,
+            "colorscale_away_retro": COLORSCALE_AWAY_RETRO,
+            "colorscale_studios": COLORSCALE_STUDIOS,
+            "colorscale_studios_retro": COLORSCALE_STUDIOS_RETRO,
+            "colorscale_home_away_studios": COLORSCALE_HOME_AWAY_STUDIOS,
+            "colorscale_home_away_studios_retro": COLORSCALE_HOME_AWAY_STUDIOS_RETRO,
         }
 
     return _config
@@ -137,8 +207,6 @@ def load_config(
         if use_pool:
             pool_name: str = str(database_config.get("pool_name", connection_pool_name))
             pool_size: int = int(database_config.get("pool_size", connection_pool_size))
-            # if pool_size < connection_pool_size:
-            #    pool_size = connection_pool_size
             _pool_size = max(pool_size, connection_pool_size)
 
             database_config["pool_name"] = pool_name

--- a/app/config.py
+++ b/app/config.py
@@ -105,14 +105,16 @@ COLORSCALE_STUDIOS_RETRO: list[float | str] = [
 
 COLORSCALE_HOME_AWAY_STUDIOS: list[float | str] = [
     [0.0, "#f1c21b"],  # IBM Alert 30 (Away)
-    [0.5, "#a56eff"],  # IBM Purple 50 (Home)
-    [1.0, "#007d79"],  # IBM Teal 60 (Home/Remote Studios)
+    [0.333333, "#a56eff"],  # IBM Purple 50 (Home)
+    [0.666667, "#007d79"],  # IBM Teal 60 (Home/Remote Studios)
+    [1.0, "#000000"],  # Black (TBD)
 ]
 
 COLORSCALE_HOME_AWAY_STUDIOS_RETRO: list[float | str] = [
-    [0.0, "#ffff66"],  # Away
-    [0.5, "#ff66ff"],  # Home
-    [1.0, "#00cc00"],  # Home/Remote Studios
+    [0.0, "#ffff66"],  # Yello (Away)
+    [0.333333, "#ff66ff"],  # Home
+    [0.666667, "#00cc00"],  # Home/Remote Studios
+    [1.0, "#000000"],  # Black (TBD)
 ]
 
 

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -5,9 +5,12 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Location Routes for Wait Wait Graphs Site."""
 
+import json
+
 from flask import Blueprint, render_template, url_for
 
 from app.reports.location import home_vs_away as home_away
+from app.reports.location import home_vs_away_year as home_away_year
 from app.reports.location import recordings_by_state as recordings_state
 from app.shows.routes import retrieve_show_years
 from app.utility import redirect_url
@@ -19,6 +22,100 @@ blueprint = Blueprint("locations", __name__, template_folder="templates")
 def index() -> str:
     """View: Locations Index."""
     return render_template("locations/index.html")
+
+
+@blueprint.route("/all-locations-shows-heatmap")
+def all_locations_shows_heatmap() -> str:
+    """View: All Locations Shows Heatmap."""
+    _shows = home_away_year.retrieve_all_locations_shows_all_years()
+
+    if not _shows:
+        return redirect_url(url_for("locations.index"))
+
+    show_years = list(_shows.keys())
+    show_numbers = [number + 1 for number in range(53)]
+
+    _data = []
+    for show_year in show_years:
+        _data.append(_shows[show_year])
+
+    return render_template(
+        "locations/all-locations-shows-heatmap/graph.html",
+        data=json.dumps(_data),
+        show_numbers=show_numbers,
+        years=show_years,
+    )
+
+
+@blueprint.route("/away-shows-heatmap")
+def away_shows_heatmap() -> str:
+    """View: Away Shows Heatmap."""
+    _away_shows = home_away_year.retrieve_away_shows_all_years()
+
+    if not _away_shows:
+        return redirect_url(url_for("locations.index"))
+
+    show_years = list(_away_shows.keys())
+    show_numbers = [number + 1 for number in range(53)]
+
+    _data = []
+    for show_year in show_years:
+        _data.append(_away_shows[show_year])
+
+    return render_template(
+        "locations/away-shows-heatmap/graph.html",
+        data=json.dumps(_data),
+        show_numbers=show_numbers,
+        years=show_years,
+    )
+
+
+@blueprint.route("/home-shows-heatmap")
+def home_shows_heatmap() -> str:
+    """View: Home Shows Heatmap."""
+    _home_shows = home_away_year.retrieve_home_shows_all_years()
+
+    if not _home_shows:
+        return redirect_url(url_for("locations.index"))
+
+    show_years = list(_home_shows.keys())
+    show_numbers = [number + 1 for number in range(53)]
+
+    _data = []
+    for show_year in show_years:
+        _data.append(_home_shows[show_year])
+
+    return render_template(
+        "locations/home-shows-heatmap/graph.html",
+        data=json.dumps(_data),
+        show_numbers=show_numbers,
+        years=show_years,
+    )
+
+
+@blueprint.route("/home-remote-studios-shows-heatmap")
+def home_remote_studios_shows_heatmap() -> str:
+    """View: Home/Remote Studios Shows Heatmap."""
+    _home_remote_studios_shows = (
+        home_away_year.retrieve_home_remote_studios_shows_all_years()
+    )
+
+    if not _home_remote_studios_shows:
+        return redirect_url(url_for("locations.index"))
+
+    show_years = list(_home_remote_studios_shows.keys())
+    show_numbers = [number + 1 for number in range(53)]
+
+    _data = []
+    for show_year in show_years:
+        _data.append(_home_remote_studios_shows[show_year])
+
+    return render_template(
+        "locations/home-remote-studios-shows-heatmap/graph.html",
+        data=json.dumps(_data),
+        show_numbers=show_numbers,
+        years=show_years,
+    )
 
 
 @blueprint.route("/home-vs-away")

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -172,3 +172,47 @@ def recordings_by_state() -> str:
         names=names,
         recordings=recordings,
     )
+
+
+@blueprint.route("/show-location-types-by-year")
+def show_location_types() -> str:
+    """View: Show Location Types."""
+    show_years = retrieve_show_years()
+
+    if not show_years:
+        return redirect_url(url_for("locations.index"))
+
+    return render_template(
+        "locations/show-location-types-by-year/index.html", show_years=show_years
+    )
+
+
+@blueprint.route("/show-location-types-by-year/<int:year>")
+def show_location_types_by_year(year: int) -> str:
+    """View: Show Location Types by Year."""
+    show_years = retrieve_show_years()
+    if year not in show_years:
+        return redirect_url(url_for("locations.show_location_types"))
+
+    _data = home_away_year.retrieve_home_away_studios_shows_by_year(year=year)
+    if not _data:
+        return redirect_url(url_for("locations.show_location_types"))
+
+    if (
+        "show_dates" in _data
+        and "home" in _data
+        and "away" in _data
+        and "studios" in _data
+        and "tbd_na" in _data
+    ):
+        return render_template(
+            "locations/show-location-types-by-year/details.html",
+            year=year,
+            show_dates=_data["show_dates"],
+            home=json.dumps(_data["home"]),
+            away=json.dumps(_data["away"]),
+            home_remote_studios=json.dumps(_data["studios"]),
+            tbd_na=json.dumps(_data["tbd_na"]),
+        )
+
+    return redirect_url(url_for("locations.show_location_types"))

--- a/app/locations/templates/locations/all-locations-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/all-locations-shows-heatmap/graph.html
@@ -21,7 +21,8 @@
 <p>
     All shows are included, including regular, Best Of, repeat and repeat Best
     Of shows. Purple or violet denotes home shows, yellow denotes away shows,
-    and green denotes home/remote studios shows.
+    green denotes home/remote studios shows, and black denotes a location that
+    is to be determined or is not available.
 </p>
 
 <div class="info py-2">

--- a/app/locations/templates/locations/all-locations-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/all-locations-shows-heatmap/graph.html
@@ -1,0 +1,155 @@
+{% extends "base.html" %}
+{% set page_title="All Locations Shows Heatmap" %}
+{% block title %}{{ page_title }} | Locations{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+
+{% if years and show_numbers and data %}
+<p>
+    This heatmap chart displays when shows that were recorded at home (any venue
+    or studio located in Chicago, Illinois), away and from home/remote studios
+    broken out by year.
+</p>
+<p>
+    All shows are included, including regular, Best Of, repeat and repeat Best
+    Of shows. Purple or violet denotes home shows, yellow denotes away shows,
+    and green denotes home/remote studios shows.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    colorscale = {{ colorscale_home_away_studios | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro"
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        fontList = "'IBM Plex Serif', serif";
+        colorscale = {{ colorscale_home_away_studios_retro | safe }};
+    };
+
+    let showNumbers = {{ show_numbers | safe }};
+    let years = {{ years | safe }};
+    let locData = {{ data | safe }};
+
+    let data = [
+        {
+            x: showNumbers,
+            y: years,
+            z: locData,
+            colorbar: {
+                tickfont: {
+                    color: axisColor,
+                    family: fontList,
+                    size: 16
+                }
+            },
+            colorscale: colorscale,
+            hoverongaps: false,
+            hovertemplate: "%{y} Show #%{x}<extra></extra>",
+            showscale: false,
+            type: "heatmap",
+            xgap: 3,
+            ygap: 3,
+            zsmooth: false
+        }
+    ];
+
+    let layout = {
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        margin: {
+            l: 128,
+            r: 64,
+            t: 64,
+            b: 64
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: false,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Show Number"
+            },
+        },
+        yaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Year"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "all-locations-shows-heatmap",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No scoring data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/locations/templates/locations/away-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/away-shows-heatmap/graph.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+{% set page_title="Away Shows Heatmap" %}
+{% block title %}{{ page_title }} | Locations{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+
+{% if years and show_numbers and data %}
+<p>
+    This heatmap chart displays when shows that were recorded away from their
+    home (any venue or studio located in Chicago, Illinois), broken down by year.
+</p>
+<p>
+    All shows are included, including regular, Best Of, repeat and repeat Best
+    Of shows. Yellow denotes away shows.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorscale = {{ colorscale_away | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro"
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        fontList = "'IBM Plex Serif', serif";
+        colorscale = {{ colorscale_away_retro | safe }};
+    };
+
+    let showNumbers = {{ show_numbers | safe }};
+    let years = {{ years | safe }};
+    let locData = {{ data | safe }};
+
+    let data = [
+        {
+            x: showNumbers,
+            y: years,
+            z: locData,
+            colorbar: {
+                tickfont: {
+                    color: axisColor,
+                    family: fontList,
+                    size: 16
+                }
+            },
+            colorscale: colorscale,
+            hoverongaps: false,
+            hovertemplate: "%{y} Show #%{x}<extra></extra>",
+            showscale: false,
+            type: "heatmap",
+            xgap: 3,
+            ygap: 3,
+            zsmooth: false
+        }
+    ];
+
+    let layout = {
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        margin: {
+            l: 128,
+            r: 64,
+            t: 64,
+            b: 64
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: false,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Show Number"
+            },
+        },
+        yaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Year"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "away-shows-heatmap",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No scoring data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/locations/templates/locations/home-remote-studios-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/home-remote-studios-shows-heatmap/graph.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+{% set page_title="Home/Remote Studio Shows Heatmap" %}
+{% block title %}{{ page_title }} | Locations{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+
+{% if years and show_numbers and data %}
+<p>
+    This heatmap chart displays when shows that were recorded at home/remote
+    studios broken down by year.
+</p>
+<p>
+    All shows are included, including regular, Best Of, repeat and repeat Best
+    Of shows. Green denotes home/remote studio shows.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorscale = {{ colorscale_studios | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro"
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        fontList = "'IBM Plex Serif', serif";
+        colorscale = {{ colorscale_studios_retro | safe }};
+    };
+
+    let showNumbers = {{ show_numbers | safe }};
+    let years = {{ years | safe }};
+    let locData = {{ data | safe }};
+
+    let data = [
+        {
+            x: showNumbers,
+            y: years,
+            z: locData,
+            colorbar: {
+                tickfont: {
+                    color: axisColor,
+                    family: fontList,
+                    size: 16
+                }
+            },
+            colorscale: colorscale,
+            hoverongaps: false,
+            hovertemplate: "%{y} Show #%{x}<extra></extra>",
+            showscale: false,
+            type: "heatmap",
+            xgap: 3,
+            ygap: 3,
+            zsmooth: false
+        }
+    ];
+
+    let layout = {
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        margin: {
+            l: 128,
+            r: 64,
+            t: 64,
+            b: 64
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: false,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Show Number"
+            },
+        },
+        yaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Year"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "home-shows-breakdown-heatmap",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No scoring data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/locations/templates/locations/home-remote-studios-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/home-remote-studios-shows-heatmap/graph.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title="Home/Remote Studio Shows Heatmap" %}
+{% set page_title="Home/Remote Studios Shows Heatmap" %}
 {% block title %}{{ page_title }} | Locations{% endblock %}
 
 {% block content %}

--- a/app/locations/templates/locations/home-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/home-shows-heatmap/graph.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+{% set page_title="Home Shows Heatmap" %}
+{% block title %}{{ page_title }} | Locations{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+
+{% if years and show_numbers and data %}
+<p>
+    This heatmap chart displays when shows that were recorded at home (any venue
+    or studio located in Chicago, Illinois) broken out by year.
+</p>
+<p>
+    All shows are included, including regular, Best Of, repeat and repeat Best
+    Of shows. Purple or violet denotes home shows.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorscale = {{ colorscale_home | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro"
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        fontList = "'IBM Plex Serif', serif";
+        colorscale = {{ colorscale_home_retro | safe }};
+    };
+
+    let showNumbers = {{ show_numbers | safe }};
+    let years = {{ years | safe }};
+    let locData = {{ data | safe }};
+
+    let data = [
+        {
+            x: showNumbers,
+            y: years,
+            z: locData,
+            colorbar: {
+                tickfont: {
+                    color: axisColor,
+                    family: fontList,
+                    size: 16
+                }
+            },
+            colorscale: colorscale,
+            hoverongaps: false,
+            hovertemplate: "%{y} Show #%{x}<extra></extra>",
+            showscale: false,
+            type: "heatmap",
+            xgap: 3,
+            ygap: 3,
+            zsmooth: false
+        }
+    ];
+
+    let layout = {
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        margin: {
+            l: 128,
+            r: 64,
+            t: 64,
+            b: 64
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: false,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Show Number"
+            },
+        },
+        yaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Year"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "home-shows-heatmap",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No scoring data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/locations/templates/locations/home-vs-away/graph.html
+++ b/app/locations/templates/locations/home-vs-away/graph.html
@@ -74,11 +74,12 @@
         font: { family: fontList },
         hoverlabel: {
             font: {
+                color: axisColor,
                 family: fontList,
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/locations/templates/locations/index.html
+++ b/app/locations/templates/locations/index.html
@@ -36,6 +36,9 @@
             <li class="list-group-item">
                 <a href="{{ url_for('locations.recordings_by_state') }}">Recordings by State</a>
             </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.show_location_types') }}">Show Location Types by Year</a>
+            </li>
         </ul>
     </div>
 </div>

--- a/app/locations/templates/locations/index.html
+++ b/app/locations/templates/locations/index.html
@@ -19,6 +19,18 @@
     <div class="pages">
         <ul class="list-group page-list">
             <li class="list-group-item">
+                <a href="{{ url_for('locations.all_locations_shows_heatmap') }}">All Locations Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.away_shows_heatmap') }}">Away Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.home_shows_heatmap') }}">Home Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.home_remote_studios_shows_heatmap') }}">Home/Remote Studios Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
                 <a href="{{ url_for('locations.home_vs_away') }}">Home vs Away</a>
             </li>
             <li class="list-group-item">

--- a/app/locations/templates/locations/show-location-types-by-year/details.html
+++ b/app/locations/templates/locations/show-location-types-by-year/details.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
-{% set page_title="Bluff the Listener Counts" %}
-{% block title %}{{ year }} | {{ page_title }} | Shows{% endblock %}
+{% set page_title = "Show Location Types by Year" %}
+{% block title %}{{ year }} | {{ page_title }} | Locations{% endblock %}
 
 {% block content %}
 <nav aria-label="breadcrumb" id="nav-breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
-        <li class="breadcrumb-item"><a href="{{ url_for('shows.bluff_counts') }}">{{ page_title }}</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.show_location_types') }}">{{ page_title }}</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ year }}</li>
     </ol>
 </nav>
 
 <h2>{{ page_title }}: {{ year }}</h2>
 
-{% if months %}
+{% if show_dates and home and away and home_remote_studios and tbd_na %}
 <p>
-    This chart displays the number of times a listener contestant has chosen
-    the correct or incorrect Bluff the Listener story, broken down by month.
+    This chart displays location type (home, away or home/away studios) for each show,
+    including regular, Best Of, repeat and repeat Best Of shows.
 </p>
 
 <div class="info py-2">
@@ -24,7 +24,7 @@
 </div>
 
 <script>
-    // Set default colors and font list
+    // Set default colors
     let axisColor = "#000";
     let backgroundColor = "#fff";
     let colorway = {{ colorway_light | safe }};
@@ -46,23 +46,35 @@
         fontList = "'IBM Plex Serif', serif";
     };
 
-    let showMonths = {{ months | safe }};
-    let correct = {{ correct | safe }};
-    let incorrect = {{ incorrect | safe }};
-    let max_height = Math.ceil(Math.max.apply(Math, correct) + Math.max.apply(Math, incorrect));
     let data = [
         {
-            x: showMonths,
-            y: correct,
-            name: "Correct",
+            x: {{ show_dates | safe }},
+            y: {{ home | safe }},
+            name: "Home",
+            showlegend: true,
             type: "bar"
         },
         {
-            x: showMonths,
-            y: incorrect,
-            name: "Incorrect",
+            x: {{ show_dates | safe }},
+            y: {{ away | safe }},
+            name: "Away",
+            showlegend: true,
             type: "bar"
-        }
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ home_remote_studios | safe }},
+            name: "Home/Remote Studios",
+            showlegend: true,
+            type: "bar"
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ tbd_na | safe }},
+            name: "TBD/NA",
+            showlegend: true,
+            type: "bar"
+        },
     ];
 
     let layout = {
@@ -73,7 +85,7 @@
         hoverlabel: {
             font: {
                 family: fontList,
-                size: 16
+                size: 15
             },
         },
         hovermode: "x unified",
@@ -92,7 +104,7 @@
             l: 60,
             r: 40,
             t: 48,
-            b: 90,
+            b: 90
         },
         paper_bgcolor: backgroundColor,
         plot_bgcolor: backgroundColor,
@@ -106,35 +118,35 @@
             pad: {
                 t: 6
             },
-            text: "{{ page_title }}: {{ year }}",
+            text: "{{ page_title }}: {{ year | safe }}",
             x: 0.01
         },
         xaxis: {
             color: axisColor,
+            nticks: 26,
+            showgrid: false,
             showspikes: true,
             spikecolor: axisColor,
             spikedash: "dot",
             spikemode: "across",
             spikethickness: 1,
             tickangle: -45,
-            tickfont: { size: 14 },
+            tickfont: { size: 13 },
             title: {
                 font: { size: 18 },
-                text: "Month"
+                text: "Show Date"
             },
-            type: "category"
+            type: "category",
+            visible: true
         },
         yaxis: {
             color: axisColor,
-            dtick: 3,
+            dtick: 1,
             fixedrange: true,
-            range: [0, max_height + 1],
             showline: true,
+            showgrid: true,
             tickfont: { size: 16 },
-            title: {
-                font: { size: 18 },
-                text: "Count"
-            }
+            visible: false
         }
     };
 
@@ -147,7 +159,7 @@
         ],
         responsive: true,
         toImageButtonOptions: {
-            filename: "bluff-counts-{{ year }}",
+            filename: "show-location-types-by-year-{{ year }}",
             height: 800,
             scale: 1,
             width: 1200
@@ -158,7 +170,7 @@
 </script>
 {% else %}
 <p>
-    No Bluff the Listener data is currently available for {{ year }}.
+    Not enough data is available for {{ year }} to generate a graph.
 </p>
 {% endif %}
 

--- a/app/locations/templates/locations/show-location-types-by-year/index.html
+++ b/app/locations/templates/locations/show-location-types-by-year/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% set page_title="Show Location Types by Year" %}
+{% block title %}{{ page_title }} | Locations{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+<p>
+    Choose from one of the years below to view the location type (home, away or
+    home/remote studios) for each show.
+</p>
+
+<div class="info">
+    <div class="panelists">
+        <ul class="list-group name-list">
+            {% for year in show_years %}
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.show_location_types_by_year', year=year) }}">{{ year }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/panelists/templates/panelists/aggregate-scores/graph.html
+++ b/app/panelists/templates/panelists/aggregate-scores/graph.html
@@ -60,11 +60,12 @@
         font: { family: fontList },
         hoverlabel: {
             font: {
+                color: axisColor,
                 family: fontList,
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         margin: {
             l: 60,
             r: 40,

--- a/app/panelists/templates/panelists/appearances-by-year/details.html
+++ b/app/panelists/templates/panelists/appearances-by-year/details.html
@@ -76,11 +76,12 @@
         font: { family: fontList },
         hoverlabel: {
             font: {
+                color: axisColor,
                 family: fontList,
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         margin: {
             l: 60,
             r: 40,

--- a/app/panelists/templates/panelists/score-breakdown/details.html
+++ b/app/panelists/templates/panelists/score-breakdown/details.html
@@ -75,11 +75,12 @@
         font: { family: fontList },
         hoverlabel: {
             font: {
+                color: axisColor,
                 family: fontList,
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         margin: {
             l: 60,
             r: 60,

--- a/app/panelists/templates/panelists/scores-by-appearance/details.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/details.html
@@ -64,11 +64,12 @@
         font: { family: fontList },
         hoverlabel: {
             font: {
+                color: axisColor,
                 family: fontList,
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         margin: {
             l: 60,
             r: 40,

--- a/app/reports/location/home_vs_away.py
+++ b/app/reports/location/home_vs_away.py
@@ -56,6 +56,7 @@ def retrieve_home_vs_away_by_year(year: int) -> dict[str, int | None] | None:
     )
     result = cursor.fetchone()
     cursor.close()
+    database_connection.close()
 
     counts = {
         "home": result["home"],

--- a/app/reports/location/home_vs_away_year.py
+++ b/app/reports/location/home_vs_away_year.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Show Home vs Away by Year Retrieval Functions."""
+
+from flask import current_app
+from mysql.connector import connect
+
+from app.reports.show.utility import retrieve_show_years
+
+_LOCATION_ID_TBD = 3
+_LOCATION_ID_HOME_REMOTE_STUDIOS = 148
+_MAX_SHOWS_PER_YEAR = 53
+
+
+def retrieve_home_location_ids() -> list[int] | None:
+    """Retrieve a list of location IDs for locations in Chicago, Illinois."""
+    database_connection = connect(**current_app.config["database"])
+
+    query = """
+        SELECT locationid FROM ww_locations
+        WHERE city = 'Chicago' AND state = 'IL'
+        ORDER BY locationid;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query)
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _ids = []
+    for row in results:
+        _ids.append(row[0])
+
+    return _ids
+
+
+def retrieve_all_locations_shows_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows with corresponding values for home, remote and studio shows.
+
+    The list contains zeroes for shows away from Chicago, IL and not from home/remote
+    studios, ones for shows recorded in Chicago, IL, and twos for home/remote studios
+    shows. The returned list will be padded out with zeroes in order to have 53 items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    _home_location_ids = retrieve_home_location_ids()
+    if not _home_location_ids:
+        return None
+
+    query = """
+        SELECT lm.locationid FROM ww_showlocationmap lm
+        JOIN ww_shows s ON s.showid = lm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _shows = []
+    for row in results:
+        if row[0] in _home_location_ids:
+            _shows.append(1)
+        elif row[0] == _LOCATION_ID_HOME_REMOTE_STUDIOS:
+            _shows.append(2)
+        else:
+            _shows.append(0)
+
+    _shows_locations_len = len(_shows)
+    if _shows_locations_len < _MAX_SHOWS_PER_YEAR:
+        _shows = _shows + ([None] * (_MAX_SHOWS_PER_YEAR - _shows_locations_len))
+
+    return _shows
+
+
+def retrieve_all_locations_shows_all_years() -> dict[int, list[int]] | None:
+    """Retrieves a dictionary containing shows denoted as home, away and home/remote studios shows.
+
+    Dictionary key is the year and each key value is a list of either
+    zeroes, ones or twos noting away, home and home/remote studios shows
+    respectively.
+    """
+    _years = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_all_locations_shows_by_year(year=year)
+
+    return _info
+
+
+def retrieve_home_shows_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows noted as home shows for a given year.
+
+    The list contains either zeroes or ones, where ones denote shows
+    recorded in Chicago, IL. The returned list will be padded out with
+    zeroes in order to have 53 items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    _home_location_ids = retrieve_home_location_ids()
+    if not _home_location_ids:
+        return None
+
+    query = """
+        SELECT lm.locationid FROM ww_showlocationmap lm
+        JOIN ww_shows s ON s.showid = lm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _shows = []
+    for row in results:
+        if row[0] in _home_location_ids:
+            _shows.append(1)
+        else:
+            _shows.append(0)
+
+    _shows_len = len(_shows)
+    if _shows_len < _MAX_SHOWS_PER_YEAR:
+        _shows = _shows + ([None] * (_MAX_SHOWS_PER_YEAR - _shows_len))
+
+    return _shows
+
+
+def retrieve_home_shows_all_years() -> dict[int, list[int]] | None:
+    """Retrieves a dictionary containing shows noted as home shows.
+
+    Dictionary key is the year and each key value is a list of either
+    zeroes or ones, where ones denote shows recorded in Chicago, IL.
+    """
+    _years = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_home_shows_by_year(year=year)
+
+    return _info
+
+
+def retrieve_away_shows_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows noted as away shows for a given year.
+
+    The list contains either zeroes or ones, where ones denote shows
+    recorded away from Chicago, IL, but exclude shows with Home/Remote
+    Studios as their location. The returned list will be padded out with
+    zeroes in order to have 53 items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    _home_location_ids = retrieve_home_location_ids()
+    # Excluding TBD and Home/Remote Studio location IDs
+    _excluded_ids = [_LOCATION_ID_TBD, _LOCATION_ID_HOME_REMOTE_STUDIOS]
+    if not _home_location_ids:
+        return None
+
+    query = """
+        SELECT lm.locationid FROM ww_showlocationmap lm
+        JOIN ww_shows s ON s.showid = lm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _shows = []
+    for row in results:
+        if row[0] in _home_location_ids or row[0] in _excluded_ids:
+            _shows.append(0)
+        else:
+            _shows.append(1)
+
+    _shows_len = len(_shows)
+    if _shows_len < _MAX_SHOWS_PER_YEAR:
+        _shows = _shows + ([0] * (_MAX_SHOWS_PER_YEAR - _shows_len))
+
+    return _shows
+
+
+def retrieve_away_shows_all_years() -> dict[int, list[int]] | None:
+    """Retrieves a dictionary containing shows noted as away shows.
+
+    Dictionary key is the year and each key value is a list of either
+    zeroes or ones, where ones denote shows recorded away from Chicago,
+    IL, but exclude shows with Home/Remote Studios as their location.
+    """
+    _years = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_away_shows_by_year(year=year)
+
+    return _info
+
+
+def retrieve_home_remote_studios_shows_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows noted as Home/Remote Studio shows for a given year.
+
+    The list contains either zeroes or ones, where ones denote shows
+    recorded from Home/Remote Studios. The returned list will be padded
+    out with zeroes in order to have 53 items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT lm.locationid FROM ww_showlocationmap lm
+        JOIN ww_shows s ON s.showid = lm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _shows = []
+    for row in results:
+        if row[0] == _LOCATION_ID_HOME_REMOTE_STUDIOS:
+            _shows.append(1)
+        else:
+            _shows.append(0)
+
+    _shows_len = len(_shows)
+    if _shows_len < _MAX_SHOWS_PER_YEAR:
+        _shows = _shows + ([0] * (_MAX_SHOWS_PER_YEAR - _shows_len))
+
+    return _shows
+
+
+def retrieve_home_remote_studios_shows_all_years() -> dict[int, list[int]] | None:
+    """Retrieves a dictionary containing shows noted as Home/Remote Studio shows.
+
+    Dictionary key is the year and each key value is a list of either
+    zeroes or ones, where ones denote shows recorded from Home/Remote Studios.
+    """
+    _years = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_home_remote_studios_shows_by_year(year=year)
+
+    return _info

--- a/app/reports/show/guests_vs_bluffs.py
+++ b/app/reports/show/guests_vs_bluffs.py
@@ -136,12 +136,15 @@ def retrieve_bluff_win_rate_by_year(
         SELECT COUNT(s.showid)
         FROM ww_showbluffmap blm
         JOIN ww_shows s ON s.showid = blm.showid
-        WHERE YEAR(s.showdate) = %s AND
-        (s.bestof = 0 AND blm.chosenbluffpnlid IS NOT NULL AND
-            blm.correctbluffpnlid IS NOT NULL) OR
-        (s.bestof = 1 AND s.bestofuniquebluff = 1 AND
-            blm.chosenbluffpnlid IS NOT NULL AND blm.correctbluffpnlid IS NOT
-            NULL);
+        WHERE YEAR(s.showdate) = %s
+        AND (
+            (s.bestof = 0 AND blm.chosenbluffpnlid IS NOT NULL AND
+            blm.correctbluffpnlid IS NOT NULL)
+            OR
+            (s.bestof = 1 AND s.bestofuniquebluff = 1 AND
+            blm.chosenbluffpnlid IS NOT NULL AND
+            blm.correctbluffpnlid IS NOT NULL)
+        );
     """
     cursor = database_connection.cursor(dictionary=False)
     cursor.execute(query, (year,))
@@ -157,10 +160,13 @@ def retrieve_bluff_win_rate_by_year(
         SELECT COUNT(s.showid)
         FROM ww_showbluffmap blm
         JOIN ww_shows s ON s.showid = blm.showid
-        WHERE YEAR(s.showdate) = %s AND
-        (s.bestof = 0 AND blm.chosenbluffpnlid = blm.correctbluffpnlid) OR
-        (s.bestof = 1 AND s.bestofuniquebluff = 1 AND
-            blm.chosenbluffpnlid = blm.correctbluffpnlid);
+        WHERE YEAR(s.showdate) = %s
+        AND (
+            (s.bestof = 0 AND blm.chosenbluffpnlid = blm.correctbluffpnlid)
+            OR
+            (s.bestof = 1 AND s.bestofuniquebluff = 1 AND
+            blm.chosenbluffpnlid = blm.correctbluffpnlid)
+        );
     """
     cursor = database_connection.cursor(dictionary=False)
     cursor.execute(query, (year,))

--- a/app/reports/show/utility.py
+++ b/app/reports/show/utility.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Shows Utility Functions."""
+
+from flask import current_app
+from mysql.connector import connect
+from wwdtm.show import Show
+
+
+def retrieve_show_years(reverse_order: bool = True) -> list[int]:
+    """Retrieve a list of available show years."""
+    database_connection = connect(**current_app.config["database"])
+    show = Show(database_connection=database_connection)
+    years = show.retrieve_years()
+    database_connection.close()
+
+    if years and reverse_order:
+        years.reverse()
+
+    return years

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -14,22 +14,10 @@ from app.reports.show.guests_vs_bluffs import (
     retrieve_bluff_win_rate_by_year,
     retrieve_not_my_job_win_rate_by_year,
 )
+from app.reports.show.utility import retrieve_show_years
 from app.utility import MONTH_NAMES, redirect_url
 
 blueprint = Blueprint("shows", __name__, template_folder="templates")
-
-
-def retrieve_show_years(reverse_order: bool = True) -> list[int]:
-    """Retrieve a list of available show years."""
-    database_connection = connect(**current_app.config["database"])
-    show = Show(database_connection=database_connection)
-    years = show.retrieve_years()
-    database_connection.close()
-
-    if years and reverse_order:
-        years.reverse()
-
-    return years
 
 
 @blueprint.route("/")

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -32,7 +32,7 @@ def all_scores() -> Response | str:
     show_years = retrieve_show_years()
 
     if not show_years:
-        return redirect_url(url_for("shows_index"))
+        return redirect_url(url_for("shows.index"))
 
     return render_template("shows/all-scores/index.html", show_years=show_years)
 
@@ -42,7 +42,7 @@ def all_scores_by_year(year: int) -> Response | str:
     """View: All Scores by Year."""
     show_years = retrieve_show_years()
     if year not in show_years:
-        return redirect_url(url_for("shows_all_scores"))
+        return redirect_url(url_for("shows.all_scores"))
 
     database_connection = connect(**current_app.config["database"])
     _show = Show(database_connection=database_connection)
@@ -96,7 +96,7 @@ def bluff_counts_all() -> Response | str:
     bluff_data = bluff_count.retrieve_all_bluff_counts()
 
     if not bluff_data:
-        return redirect_url(url_for("shows_bluff_counts"))
+        return redirect_url(url_for("shows.bluff_counts"))
 
     _dates = list(bluff_data.keys())
     correct = []
@@ -224,7 +224,7 @@ def counts_by_year() -> Response | str:
     counts = show_counts.retrieve_show_counts_by_year()
 
     if not counts:
-        return redirect_url(url_for("shows_index"))
+        return redirect_url(url_for("shows.index"))
 
     years = []
     regular = []
@@ -327,7 +327,7 @@ def panel_gender_mix() -> Response | str:
     panel_mix = gender_mix.panel_gender_mix_breakdown()
 
     if not panel_mix:
-        return redirect_url(url_for("shows_index"))
+        return redirect_url(url_for("shows.index"))
 
     years = []
     panel_0f = []

--- a/app/shows/templates/shows/all-scores/details.html
+++ b/app/shows/templates/shows/all-scores/details.html
@@ -79,7 +79,7 @@
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,
@@ -120,7 +120,7 @@
             spikemode: "across",
             spikethickness: 1,
             tickangle: -45,
-            tickfont: { size: 14 },
+            tickfont: { size: 13 },
             title: {
                 font: { size: 18 },
                 text: "Show Date"

--- a/app/shows/templates/shows/bluff-counts/all.html
+++ b/app/shows/templates/shows/bluff-counts/all.html
@@ -77,7 +77,7 @@
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/shows/templates/shows/counts-by-day-month/all.html
+++ b/app/shows/templates/shows/counts-by-day-month/all.html
@@ -99,7 +99,7 @@
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/shows/templates/shows/counts-by-day-month/details.html
+++ b/app/shows/templates/shows/counts-by-day-month/details.html
@@ -88,10 +88,10 @@
         hoverlabel: {
             font: {
                 family: fontList,
-                size: 16
+                size: 15
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/shows/templates/shows/counts-by-year/graph.html
+++ b/app/shows/templates/shows/counts-by-year/graph.html
@@ -86,10 +86,10 @@
         hoverlabel: {
             font: {
                 family: fontList,
-                size: 16
+                size: 15
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
+++ b/app/shows/templates/shows/monthly-aggregate-score-heatmap/graph.html
@@ -86,7 +86,7 @@
         hoverlabel: {
             font: {
                 family: fontList,
-                size: 16
+                size: 15
             },
         },
         margin: {

--- a/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
+++ b/app/shows/templates/shows/not-my-job-vs-bluff-win-ratios/graph.html
@@ -93,7 +93,7 @@
                 size: 16,
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/shows/templates/shows/panel-gender-mix/graph.html
+++ b/app/shows/templates/shows/panel-gender-mix/graph.html
@@ -83,7 +83,7 @@
                 size: 16
             },
         },
-        hovermode: "x",
+        hovermode: "x unified",
         legend: {
             font: {
                 color: axisColor,

--- a/app/static/js/plotly.min.js
+++ b/app/static/js/plotly.min.js
@@ -1,1 +1,1 @@
-plotly-3.3.0.min.js
+plotly-3.3.1.min.js

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -24,6 +24,18 @@
                 <h3>Locations</h3>
             </li>
             <li class="list-group-item">
+                <a href="{{ url_for('locations.all_locations_shows_heatmap') }}">All Locations Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.away_shows_heatmap') }}">Away Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.home_shows_heatmap') }}">Home Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.home_remote_studios_shows_heatmap') }}">Home/Remote Studios Shows Heatmap</a>
+            </li>
+            <li class="list-group-item">
                 <a href="{{ url_for('locations.home_vs_away') }}">Home vs Away</a>
             </li>
             <li class="list-group-item">

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -41,6 +41,9 @@
             <li class="list-group-item">
                 <a href="{{ url_for('locations.recordings_by_state') }}">Recordings by State</a>
             </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('locations.show_location_types') }}">Show Location Types by Year</a>
+            </li>
         </ul>
     </div>
 

--- a/app/templates/sitemaps/sitemap.xml
+++ b/app/templates/sitemaps/sitemap.xml
@@ -33,6 +33,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("locations.show_location_types") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("panelists.index") }}</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/app/templates/sitemaps/sitemap.xml
+++ b/app/templates/sitemaps/sitemap.xml
@@ -9,7 +9,23 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>{{ site_url }}{{ url_for("locations.home_vs_away") }}</loc>
+    <loc>{{ site_url }}{{ url_for("locations.all_locations_shows_heatmap") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("locations.away_shows_heatmap") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("locations.home_shows_heatmap") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("locations.home_remote_studios_shows_heatmap") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+  <loc>{{ site_url }}{{ url_for("locations.home_vs_away") }}</loc>
     <changefreq>weekly</changefreq>
   </url>
   <url>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.8.3"
+APP_VERSION = "3.9.0"

--- a/colors.yaml
+++ b/colors.yaml
@@ -88,11 +88,13 @@ colorscale_studios_retro:
   - [1.0, "#00cc00"]
 
 colorscale_home_away_studios:
-  - [0.0, "#f1c21b"] # Black (Away)
-  - [0.5, "#a56eff"] # IBM Purple 50 (Home)
-  - [1.0, "#007d79"] # IBM Magenta 40 (Home/Remote Studios)
+  - [0.0, "#f1c21b"] # IBM Alert 30 (Away)
+  - [0.333333, "#a56eff"] # IBM Purple 50 (Home)
+  - [0.666667, "#007d79"] # IBM Magenta 40 (Home/Remote Studios)
+  - [1.0, "#000000"] # Black (TBD)
 
 colorscale_home_away_studios_retro:
-  - [0.0, "#ffff66"] # Away
-  - [0.5, "#ff66ff"] # Home
-  - [1.0, "#00cc00"] # Home/Remote Studios
+  - [0.0, "#ffff66"] # Yello (Away)
+  - [0.333333, "#ff66ff"] # Home
+  - [0.666667, "#00cc00"] # Home/Remote Studios
+  - [1.0, "#000000"] # Black (TBD)

--- a/colors.yaml
+++ b/colors.yaml
@@ -61,3 +61,38 @@ colorscale_retro:
   - [0.6, "#9900ff"]
   - [0.8, "#ff99ff"]
   - [1.0, "#ffccff"]
+
+# Custom color scale for home, away and home/remote studio heatmaps
+colorscale_home:
+  - [0.0, "#000000"] # Black
+  - [1.0, "#a56eff"] # IBM Purple 50
+
+colorscale_home_retro:
+  - [0.0, "#000000"] # Black
+  - [1.0, "#ff66ff"]
+
+colorscale_away:
+  - [0.0, "#000000"] # Black
+  - [1.0, "#f1c21b"] # IBM Alert 30
+
+colorscale_away_retro:
+  - [0.0, "#000000"] # Black
+  - [1.0, "#ff66ff"]
+
+colorscale_studios:
+  - [0.0, "#000000"] # Black
+  - [1.0, "#007d79"] # IBM Teal 60
+
+colorscale_studios_retro:
+  - [0.0, "#000000"] # Black
+  - [1.0, "#00cc00"]
+
+colorscale_home_away_studios:
+  - [0.0, "#f1c21b"] # Black (Away)
+  - [0.5, "#a56eff"] # IBM Purple 50 (Home)
+  - [1.0, "#007d79"] # IBM Magenta 40 (Home/Remote Studios)
+
+colorscale_home_away_studios_retro:
+  - [0.0, "#ffff66"] # Away
+  - [0.5, "#ff66ff"] # Home
+  - [1.0, "#00cc00"] # Home/Remote Studios

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -18,6 +18,38 @@ def test_index(client: FlaskClient) -> None:
     assert b"Recordings by State" in response.data
 
 
+def test_all_locations_shows_heatmap(client: FlaskClient) -> None:
+    """Testing locations.all_locations_shows_heatmap."""
+    response: TestResponse = client.get("/locations/all-locations-shows-heatmap")
+    assert response.status_code == 200
+    assert b"All Locations Shows Heatmap" in response.data
+    assert b"plotly" in response.data
+
+
+def test_away_shows_heatmap(client: FlaskClient) -> None:
+    """Testing locations.away_shows_heatmap."""
+    response: TestResponse = client.get("/locations/away-shows-heatmap")
+    assert response.status_code == 200
+    assert b"Away Shows Heatmap" in response.data
+    assert b"plotly" in response.data
+
+
+def test_home_shows_heatmap(client: FlaskClient) -> None:
+    """Testing locations.home_shows_heatmap."""
+    response: TestResponse = client.get("/locations/home-shows-heatmap")
+    assert response.status_code == 200
+    assert b"Home Shows Heatmap" in response.data
+    assert b"plotly" in response.data
+
+
+def test_home_remote_studios_shows_heatmap(client: FlaskClient) -> None:
+    """Testing locations.home_remote_studios_shows_heatmap."""
+    response: TestResponse = client.get("/locations/home-remote-studios-shows-heatmap")
+    assert response.status_code == 200
+    assert b"Home/Remote Studios Shows Heatmap" in response.data
+    assert b"plotly" in response.data
+
+
 def test_home_vs_away(client: FlaskClient) -> None:
     """Testing locations.home_vs_away."""
     response: TestResponse = client.get("/locations/home-vs-away")

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -74,7 +74,7 @@ def test_show_location_types(client: FlaskClient) -> None:
     assert b"Show Location Types by Year" in response.data
 
 
-@pytest.mark.parametrize("year", [2006, 2020])
+@pytest.mark.parametrize("year", [2006, 2020, 2025])
 def test_show_location_types_by_year(client: FlaskClient, year: int) -> None:
     """Testing locations.show_location_types_by_year."""
     response: TestResponse = client.get(

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Locations Module and Blueprint Views."""
 
+import pytest
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
@@ -64,3 +65,22 @@ def test_recordings_by_state(client: FlaskClient) -> None:
     assert response.status_code == 200
     assert b"Recordings by State" in response.data
     assert b"choropleth" in response.data
+
+
+def test_show_location_types(client: FlaskClient) -> None:
+    """Testing locations.show_location_types."""
+    response: TestResponse = client.get("/locations/show-location-types-by-year")
+    assert response.status_code == 200
+    assert b"Show Location Types by Year" in response.data
+
+
+@pytest.mark.parametrize("year", [2006, 2020])
+def test_show_location_types_by_year(client: FlaskClient, year: int) -> None:
+    """Testing locations.show_location_types_by_year."""
+    response: TestResponse = client.get(
+        f"/locations/show-location-types-by-year/{year}"
+    )
+    assert response.status_code == 200
+    assert b"Show Location Types by Year" in response.data
+    assert b"Home/Remote Studios" in response.data
+    assert b"plotly" in response.data


### PR DESCRIPTION
## Application Changes

- Added four new heatmaps that plot shows that were recorded at home (in Chicago, Illinois), away from Chicago, and shows recorded from home/remote studios. The fourth heatmap overlays all three location types in one heatmap.
  - Hovering over each block in the heatmap only displays the year and the show number for that year
  - Displaying the show date instead of the show number of a given year leads to issues with the heatmap due to dates not aligning correct and issues with rendering the axis
- Added a new Locations "Show Location Types by Year" chart that plots out the location type (home, remote, home/remote studios) for each show for a given year
- Added a new set of colorscales for the new location heatmaps that use a different set of colors from the other colorscales due to the need to make each one distinct from each other when mixed in with other colors. The colors were chosen to ensure that they are distinct and have enough contrast for people with forms of visual impairments
- Changed hover format for line and bar charts to use a unified hover box to combine multiple x-axis values to make it easier to read
- Fixed the Bluff the Listener database queries for the "Not My Job vs Bluff the Listener Win Ratios" chart that had incorrect filters causing additional data to be included and counted for

## Component Updates

- Upgraded Plotly.js from 3.3.0 to 3.3.1