### PR TITLE
Adding Show Host/Scorekeeper Types by Year and Show Hosts/Scorekeepers Heatmap Charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 3.10.0
+
+### Application Changes
+
+- Added "Show Host Types by Year" and "Show Scorekeeper Types by Year" bar charts that plots out each show for a given year and displays one color if a show had a regular host or scorekeeper and another for guest host or scorekeeper
+- Added "Show Hosts Heatmap" and "Show Scorekeepers Heatmap" charts that displays whether a show had a regular or a guest host or scorekeeper, respectively
+  - Hovering over each block in the heatmap only displays the year and the show number for that year
+  - Displaying the show date instead of the show number of a given year leads to issues with the heatmap due to dates not aligning correct and issues with rendering the axis
+- Added a new set of colorscales for the "Show Hosts Heatma" and "Show Scorekeepers Heatmap"
+- Corrected the `colorscale_away_retro` value for `1.0` to `#ffff66` in `colors.yaml` to match the corresponding default listed in `app/config.py`
+- Corrected the HTML class to `pages` for several index pages for consistency
+
 ## 3.9.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,10 +13,12 @@ from wwdtm import VERSION as WWDTM_VERSION
 
 from app import config, utility
 from app.errors import handlers
+from app.hosts.routes import blueprint as hosts_bp
 from app.locations.routes import blueprint as locations_bp
 from app.main.redirects import blueprint as redirects_bp
 from app.main.routes import blueprint as main_bp
 from app.panelists.routes import blueprint as panelists_bp
+from app.scorekeepers.routes import blueprint as scorekeepers_bp
 from app.shows.routes import blueprint as shows_bp
 from app.sitemaps.routes import blueprint as sitemaps_bp
 from app.version import APP_VERSION
@@ -110,6 +112,12 @@ def create_app():
     app.jinja_env.globals["colorscale_home_away_studios_retro"] = json.dumps(
         _colors["colorscale_home_away_studios_retro"]
     )
+    app.jinja_env.globals["colorscale_hosts_scorekeepers"] = json.dumps(
+        _colors["colorscale_hosts_scorekeepers"]
+    )
+    app.jinja_env.globals["colorscale_hosts_scorekeepers_retro"] = json.dumps(
+        _colors["colorscale_hosts_scorekeepers_retro"]
+    )
     app.jinja_env.globals["colorscale_retro"] = json.dumps(_colors["colorscale_retro"])
     app.jinja_env.globals["colorway_light"] = json.dumps(_colors["colorway_light"])
     app.jinja_env.globals["colorway_dark"] = json.dumps(_colors["colorway_dark"])
@@ -128,8 +136,10 @@ def create_app():
     app.register_blueprint(main_bp)
     app.register_blueprint(redirects_bp)
     app.register_blueprint(sitemaps_bp)
+    app.register_blueprint(hosts_bp, url_prefix="/hosts")
     app.register_blueprint(locations_bp, url_prefix="/locations")
     app.register_blueprint(panelists_bp, url_prefix="/panelists")
+    app.register_blueprint(scorekeepers_bp, url_prefix="/scorekeepers")
     app.register_blueprint(shows_bp, url_prefix="/shows")
 
     return app

--- a/app/config.py
+++ b/app/config.py
@@ -117,6 +117,15 @@ COLORSCALE_HOME_AWAY_STUDIOS_RETRO: list[float | str] = [
     [1.0, "#000000"],  # Black (TBD)
 ]
 
+COLORSCALE_HOSTS_SCOREKEEPERS: list[float | str] = [
+    [0.0, "#a56eff"],  # IBM Purple 50
+    [1.0, "#f1c21b"],  # IBM Alert 30
+]
+COLORSCALE_HOSTS_SCOREKEEPERS_RETRO: list[float | str] = [
+    [0.0, "#ff66ff"],
+    [1.0, "#ffff66"],
+]
+
 
 def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
     """Read colors YAML configuration file."""
@@ -160,6 +169,13 @@ def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
             "colorscale_home_away_studios_retro": colors_config.get(
                 "colorscale_home_away_studios_retro", COLORSCALE_HOME_AWAY_STUDIOS_RETRO
             ),
+            "colorscale_hosts_scorekeepers": colors_config.get(
+                "colorscale_hosts_scorekeepers", COLORSCALE_HOSTS_SCOREKEEPERS
+            ),
+            "colorscale_hosts_scorekeepers_retro": colors_config.get(
+                "colorscale_hosts_scorekeepers_retro",
+                COLORSCALE_HOSTS_SCOREKEEPERS_RETRO,
+            ),
         }
     else:
         _config = {
@@ -179,6 +195,8 @@ def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
             "colorscale_studios_retro": COLORSCALE_STUDIOS_RETRO,
             "colorscale_home_away_studios": COLORSCALE_HOME_AWAY_STUDIOS,
             "colorscale_home_away_studios_retro": COLORSCALE_HOME_AWAY_STUDIOS_RETRO,
+            "colorscale_hosts_scorekeepers": COLORSCALE_HOSTS_SCOREKEEPERS,
+            "colorscale_hosts_scorekeepers_retro": COLORSCALE_HOSTS_SCOREKEEPERS_RETRO,
         }
 
     return _config

--- a/app/hosts/__init__.py
+++ b/app/hosts/__init__.py
@@ -3,6 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Application Version for Wait Wait Graphs Site."""
-
-APP_VERSION = "3.10.0"
+"""Hosts Modules for Wait Wait Graphs Site."""

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Hosts Routes for Wait Wait Graphs Site."""
+
+import json
+
+from flask import Blueprint, render_template, url_for
+
+from app.reports.hosts import host_years
+from app.shows.routes import retrieve_show_years
+from app.utility import redirect_url
+
+blueprint = Blueprint("hosts", __name__, template_folder="templates")
+
+
+@blueprint.route("/")
+def index() -> str:
+    """View: Hosts Index."""
+    return render_template("hosts/index.html")
+
+
+@blueprint.route("/show-hosts-heatmap")
+def show_hosts_heatmap() -> str:
+    """View: Show Hosts Heatmap."""
+    _shows = host_years.retrieve_host_types_all_years()
+
+    if not _shows:
+        return redirect_url(url_for("hosts.index"))
+
+    show_years = list(_shows.keys())
+    show_numbers = [number + 1 for number in range(53)]
+
+    _data = []
+    for show_year in show_years:
+        _data.append(_shows[show_year])
+
+    return render_template(
+        "hosts/show-hosts-heatmap/graph.html",
+        data=json.dumps(_data),
+        show_numbers=show_numbers,
+        years=show_years,
+    )
+
+
+@blueprint.route("/show-host-types-by-year")
+def show_host_types() -> str:
+    """View: Show Host Types by Year."""
+    show_years = retrieve_show_years()
+
+    if not show_years:
+        return redirect_url(url_for("hosts.index"))
+
+    return render_template(
+        "hosts/show-host-types-by-year/index.html", show_years=show_years
+    )
+
+
+@blueprint.route("/show-host-types-by-year/<int:year>")
+def show_host_types_by_year(year: int) -> str:
+    """View: Show Host Types by Year."""
+    show_years = retrieve_show_years()
+    if year not in show_years:
+        return redirect_url(url_for("hosts.show_host_types"))
+
+    _data = host_years.retrieve_host_types_by_year_with_dates(year=year)
+    if not _data:
+        return redirect_url(url_for("hosts.show_host_types"))
+
+    if "show_dates" in _data and "regulars" in _data and "guests" in _data:
+        return render_template(
+            "hosts/show-host-types-by-year/details.html",
+            year=year,
+            show_dates=_data["show_dates"],
+            regulars=json.dumps(_data["regulars"]),
+            guests=json.dumps(_data["guests"]),
+        )
+
+    return redirect_url(url_for("hosts.show_host_types"))

--- a/app/hosts/templates/hosts/index.html
+++ b/app/hosts/templates/hosts/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% set page_title="Hosts" %}
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+<p>
+    Choose from one of the following links to view graphs representing data
+    collected for show hosts.
+</p>
+
+<div class="info">
+    <div class="pages">
+        <ul class="list-group page-list">
+            <li class="list-group-item">
+                <a href="{{ url_for('hosts.show_host_types') }}">Show Host Types by Year</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('hosts.show_hosts_heatmap') }}">Show Hosts Heatmap</a>
+            </li>
+        </ul>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/hosts/templates/hosts/show-host-types-by-year/details.html
+++ b/app/hosts/templates/hosts/show-host-types-by-year/details.html
@@ -1,0 +1,163 @@
+{% extends "base.html" %}
+{% set page_title = "Show Host Types by Year" %}
+{% block title %}{{ year }} | {{ page_title }} | Hosts{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('hosts.index') }}">Hosts</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('hosts.show_host_types') }}">{{ page_title }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ year }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}: {{ year }}</h2>
+
+{% if show_dates and regulars and guests %}
+<p>
+    This chart displays show host type (regular host or guest host) for each
+    show, including regular, Best Of, repeat and repeat Best Of shows.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorway = {{ colorway_light | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro";
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+        colorway = {{ colorway_dark | safe }};
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        colorway = {{ colorway_retro | safe }};
+        fontList = "'IBM Plex Serif', serif";
+    };
+
+    let data = [
+        {
+            x: {{ show_dates | safe }},
+            y: {{ regulars | safe }},
+            name: "Regular",
+            showlegend: true,
+            type: "bar"
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ guests | safe }},
+            name: "Guest",
+            showlegend: true,
+            type: "bar"
+        }
+    ];
+
+    let layout = {
+        autosize: true,
+        barmode: "stack",
+        colorway: colorway,
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 15
+            },
+        },
+        hovermode: "x unified",
+        legend: {
+            font: {
+                color: axisColor,
+                family: fontList,
+                size: 16
+            },
+            traceorder: "normal",
+            orientation: "h",
+            y: 1.025,
+            x: 0,
+        },
+        margin: {
+            l: 60,
+            r: 40,
+            t: 48,
+            b: 90
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: true,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ year | safe }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            nticks: 26,
+            showgrid: false,
+            showspikes: true,
+            spikecolor: axisColor,
+            spikedash: "dot",
+            spikemode: "across",
+            spikethickness: 1,
+            tickangle: -45,
+            tickfont: { size: 13 },
+            title: {
+                font: { size: 18 },
+                text: "Show Date"
+            },
+            type: "category",
+            visible: true
+        },
+        yaxis: {
+            color: axisColor,
+            dtick: 1,
+            fixedrange: true,
+            showline: true,
+            showgrid: true,
+            tickfont: { size: 16 },
+            visible: false
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "show-host-types-by-year-{{ year }}",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    Not enough data is available for {{ year }} to generate a graph.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/hosts/templates/hosts/show-host-types-by-year/index.html
+++ b/app/hosts/templates/hosts/show-host-types-by-year/index.html
@@ -1,27 +1,27 @@
 {% extends "base.html" %}
-{% set page_title="Score Breakdown" %}
-{% block title %}{{ page_title }} | Panelists{% endblock %}
+{% set page_title="Show Host Types by Year" %}
+{% block title %}{{ page_title }} | Hosts{% endblock %}
 
 {% block content %}
 <nav aria-label="breadcrumb" id="nav-breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url_for('panelists.index') }}">Panelists</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('hosts.index') }}">Hosts</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
     </ol>
 </nav>
 
 <h2>{{ page_title }}</h2>
 <p>
-    Choose from one of the panelists below to view a chart displaying a
-    breakdown of their scores.
+    Choose from one of the years below to view the show host type (regular host or
+    guest host) for each show.
 </p>
 
 <div class="info">
     <div class="pages">
         <ul class="list-group name-list">
-            {% for panelist in panelists %}
+            {% for year in show_years %}
             <li class="list-group-item">
-                <a href="{{ url_for('panelists.score_breakdown_details', panelist=panelist.slug) }}">{{ panelist.name }}</a>
+                <a href="{{ url_for('hosts.show_host_types_by_year', year=year) }}">{{ year }}</a>
             </li>
             {% endfor %}
         </ul>

--- a/app/hosts/templates/hosts/show-hosts-heatmap/graph.html
+++ b/app/hosts/templates/hosts/show-hosts-heatmap/graph.html
@@ -1,0 +1,154 @@
+{% extends "base.html" %}
+{% set page_title="Show Hosts Heatmap" %}
+{% block title %}{{ page_title }} | Hosts{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('hosts.index') }}">Hosts</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+
+{% if years and show_numbers and data %}
+<p>
+    This heatmap chart displays when shows had a regular or a guest host broken out
+    by year.
+</p>
+<p>
+    All shows are included, including regular, Best Of, repeat and repeat Best
+    Of shows. Purple or violet denotes shows with a regular host and yellow
+    denotes shows with a guest host.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorscale = {{ colorscale_hosts_scorekeepers | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro"
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        fontList = "'IBM Plex Serif', serif";
+        colorscale = {{ colorscale_hosts_scorekeepers_retro | safe }};
+    };
+
+    let showNumbers = {{ show_numbers | safe }};
+    let years = {{ years | safe }};
+    let locData = {{ data | safe }};
+
+    let data = [
+        {
+            x: showNumbers,
+            y: years,
+            z: locData,
+            colorbar: {
+                tickfont: {
+                    color: axisColor,
+                    family: fontList,
+                    size: 16
+                }
+            },
+            colorscale: colorscale,
+            hoverongaps: false,
+            hovertemplate: "%{y} Show #%{x}<extra></extra>",
+            showscale: false,
+            type: "heatmap",
+            xgap: 3,
+            ygap: 3,
+            zsmooth: false
+        }
+    ];
+
+    let layout = {
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        margin: {
+            l: 128,
+            r: 64,
+            t: 64,
+            b: 64
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: false,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Show Number"
+            },
+        },
+        yaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Year"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "show-hosts-heatmap",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No scoring data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -176,7 +176,7 @@ def recordings_by_state() -> str:
 
 @blueprint.route("/show-location-types-by-year")
 def show_location_types() -> str:
-    """View: Show Location Types."""
+    """View: Show Location Types by Year."""
     show_years = retrieve_show_years()
 
     if not show_years:

--- a/app/panelists/templates/panelists/appearances-by-year/index.html
+++ b/app/panelists/templates/panelists/appearances-by-year/index.html
@@ -18,7 +18,7 @@
 </p>
 
 <div class="info">
-    <div class="panelists">
+    <div class="pages">
         <ul class="list-group name-list">
             {% for panelist in panelists %}
             <li class="list-group-item">

--- a/app/panelists/templates/panelists/scores-by-appearance/index.html
+++ b/app/panelists/templates/panelists/scores-by-appearance/index.html
@@ -18,7 +18,7 @@
 </p>
 
 <div class="info">
-    <div class="panelists">
+    <div class="pages">
         <ul class="list-group name-list">
             {% for panelist in panelists %}
             <li class="list-group-item">

--- a/app/reports/hosts/__init__.py
+++ b/app/reports/hosts/__init__.py
@@ -3,6 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Application Version for Wait Wait Graphs Site."""
-
-APP_VERSION = "3.10.0"
+"""Hosts Module for Wait Wait Graphs Site."""

--- a/app/reports/hosts/__init__.py
+++ b/app/reports/hosts/__init__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Hosts Module for Wait Wait Graphs Site."""
+"""Hosts Reports Module for Wait Wait Graphs Site."""

--- a/app/reports/hosts/host_years.py
+++ b/app/reports/hosts/host_years.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Host Types Retrieval Functions."""
+
+from flask import current_app
+from mysql.connector import connect
+
+from app.reports.location.home_vs_away_year import _MAX_SHOWS_PER_YEAR
+from app.reports.show.utility import retrieve_show_years
+
+
+def retrieve_host_types_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows for a given year with corresponding value for normal or guest hosts.
+
+    The list contains zeroes for regular hosts and ones for guest hosts. The
+    returned list will be padded out with zeroes in order to have 53 items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT hm.guest FROM ww_showhostmap hm
+        JOIN ww_shows s ON s.showid = hm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _hosts = []
+    for row in results:
+        if bool(row[0]):
+            _hosts.append(1)
+        else:
+            _hosts.append(0)
+
+    _hosts_len = len(_hosts)
+    if _hosts_len < _MAX_SHOWS_PER_YEAR:
+        _hosts = _hosts + ([None] * (_MAX_SHOWS_PER_YEAR - _hosts_len))
+
+    return _hosts
+
+
+def retrieve_host_types_by_year_with_dates(
+    year: int,
+) -> dict[str, list[int | str]] | None:
+    """Retrieve all shows for a given year with values for normal or guest hosts.
+
+    The dictionary contains two lists, one with show dates and a list each
+    denoting regular and guest hosts with ones denoting the corresponding type.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT s.showdate, hm.guest FROM ww_showhostmap hm
+        JOIN ww_shows s ON s.showid = hm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _show_dates = []
+    _regulars = []
+    _guests = []
+
+    for row in results:
+        _show_dates.append(row[0].isoformat())
+        if bool(row[1]):
+            _regulars.append(None)
+            _guests.append(1)
+
+        else:
+            _regulars.append(1)
+            _guests.append(None)
+
+    return {
+        "show_dates": _show_dates,
+        "regulars": _regulars,
+        "guests": _guests,
+    }
+
+
+def retrieve_host_types_all_years() -> dict[int, list[int]] | None:
+    """Retrieves a dictionary containing show hosts noted as regular or guest hosts.
+
+    Dictionary key is the year and each key value is a list of either
+    zeroes or ones, where ones denote guest hosts.
+    """
+    _years = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_host_types_by_year(year=year)
+
+    return _info

--- a/app/reports/location/__init__.py
+++ b/app/reports/location/__init__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Locations Module for Wait Wait Graphs Site."""
+"""Locations Reports Module for Wait Wait Graphs Site."""

--- a/app/reports/panel/__init__.py
+++ b/app/reports/panel/__init__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Panel Reports Module for Wait Wait Graphs Site."""
+"""Panelists Reports Module for Wait Wait Graphs Site."""

--- a/app/reports/scorekeepers/__init__.py
+++ b/app/reports/scorekeepers/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Scorekeepers Reports Module for Wait Wait Graphs Site."""

--- a/app/reports/scorekeepers/scorekeeper_years.py
+++ b/app/reports/scorekeepers/scorekeeper_years.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Scorekeeper Types Retrieval Functions."""
+
+from flask import current_app
+from mysql.connector import connect
+
+from app.reports.location.home_vs_away_year import _MAX_SHOWS_PER_YEAR
+from app.reports.show.utility import retrieve_show_years
+
+
+def retrieve_scorekeeper_types_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows for a given year with corresponding value for normal or guest scorekeepers.
+
+    The list contains zeroes for regular hosts and ones for guest scorekeepers.
+    The returned list will be padded out with zeroes in order to have 53 items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT skm.guest FROM ww_showskmap skm
+        JOIN ww_shows s ON s.showid = skm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _scorekeepers = []
+    for row in results:
+        if bool(row[0]):
+            _scorekeepers.append(1)
+        else:
+            _scorekeepers.append(0)
+
+    _scorekeepers_len = len(_scorekeepers)
+    if _scorekeepers_len < _MAX_SHOWS_PER_YEAR:
+        _scorekeepers = _scorekeepers + (
+            [None] * (_MAX_SHOWS_PER_YEAR - _scorekeepers_len)
+        )
+
+    return _scorekeepers
+
+
+def retrieve_scorekeeper_types_by_year_with_dates(
+    year: int,
+) -> dict[str, list[int | str]] | None:
+    """Retrieve all shows for a given year with values for normal or guest scorekeepers.
+
+    The dictionary contains two lists, one with show dates and a list each
+    denoting regular and guest scorekeepers with ones denoting the corresponding
+    type.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT s.showdate, skm.guest FROM ww_showskmap skm
+        JOIN ww_shows s ON s.showid = skm.showid
+        WHERE YEAR(s.showdate) = %s
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _show_dates = []
+    _regulars = []
+    _guests = []
+
+    for row in results:
+        _show_dates.append(row[0].isoformat())
+        if bool(row[1]):
+            _regulars.append(None)
+            _guests.append(1)
+
+        else:
+            _regulars.append(1)
+            _guests.append(None)
+
+    return {
+        "show_dates": _show_dates,
+        "regulars": _regulars,
+        "guests": _guests,
+    }
+
+
+def retrieve_scorekeeper_types_all_years() -> dict[int, list[int]] | None:
+    """Retrieves a dictionary containing show scorekeepers noted as regular or guest scorekeepers.
+
+    Dictionary key is the year and each key value is a list of either
+    zeroes or ones, where ones denote guest scorekeepers.
+    """
+    _years = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_scorekeeper_types_by_year(year=year)
+
+    return _info

--- a/app/reports/show/__init__.py
+++ b/app/reports/show/__init__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Shows Module for Wait Wait Graphs Site."""
+"""Shows Reports Module for Wait Wait Graphs Site."""

--- a/app/scorekeepers/__init__.py
+++ b/app/scorekeepers/__init__.py
@@ -3,6 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
-"""Application Version for Wait Wait Graphs Site."""
-
-APP_VERSION = "3.10.0"
+"""Scorekeepers Modules for Wait Wait Graphs Site."""

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Scorekeepers Routes for Wait Wait Graphs Site."""
+
+import json
+
+from flask import Blueprint, render_template, url_for
+
+from app.reports.scorekeepers import scorekeeper_years
+from app.shows.routes import retrieve_show_years
+from app.utility import redirect_url
+
+blueprint = Blueprint("scorekeepers", __name__, template_folder="templates")
+
+
+@blueprint.route("/")
+def index() -> str:
+    """View: Scorekeepers Index."""
+    return render_template("scorekeepers/index.html")
+
+
+@blueprint.route("/show-scorekeepers-heatmap")
+def show_scorekeepers_heatmap() -> str:
+    """View: Show Scorekeepers Heatmap."""
+    _shows = scorekeeper_years.retrieve_scorekeeper_types_all_years()
+
+    if not _shows:
+        return redirect_url(url_for("scorekeepers.index"))
+
+    show_years = list(_shows.keys())
+    show_numbers = [number + 1 for number in range(53)]
+
+    _data = []
+    for show_year in show_years:
+        _data.append(_shows[show_year])
+
+    return render_template(
+        "scorekeepers/show-scorekeepers-heatmap/graph.html",
+        data=json.dumps(_data),
+        show_numbers=show_numbers,
+        years=show_years,
+    )
+
+
+@blueprint.route("/show-scorekeeper-types-by-year")
+def show_scorekeeper_types() -> str:
+    """View: Show Scorekeeper Types by Year."""
+    show_years = retrieve_show_years()
+
+    if not show_years:
+        return redirect_url(url_for("scorekeepers.index"))
+
+    return render_template(
+        "scorekeepers/show-scorekeeper-types-by-year/index.html", show_years=show_years
+    )
+
+
+@blueprint.route("/show-scorekeeper-types-by-year/<int:year>")
+def show_scorekeeper_types_by_year(year: int) -> str:
+    """View: Show Scorekeeper Types by Year."""
+    show_years = retrieve_show_years()
+    if year not in show_years:
+        return redirect_url(url_for("scorekeepers.show_scorekeeper_types"))
+
+    _data = scorekeeper_years.retrieve_scorekeeper_types_by_year_with_dates(year=year)
+    if not _data:
+        return redirect_url(url_for("scorekeepers.show_scorekeeper_types"))
+
+    if "show_dates" in _data and "regulars" in _data and "guests" in _data:
+        return render_template(
+            "scorekeepers/show-scorekeeper-types-by-year/details.html",
+            year=year,
+            show_dates=_data["show_dates"],
+            regulars=json.dumps(_data["regulars"]),
+            guests=json.dumps(_data["guests"]),
+        )
+
+    return redirect_url(url_for("scorekeepers.show_scorekeeper_types"))

--- a/app/scorekeepers/templates/scorekeepers/index.html
+++ b/app/scorekeepers/templates/scorekeepers/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% set page_title="Scorekeepers" %}
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+<p>
+    Choose from one of the following links to view graphs representing data
+    collected for show scorekeepers.
+</p>
+
+<div class="info">
+    <div class="pages">
+        <ul class="list-group page-list">
+            <li class="list-group-item">
+                <a href="{{ url_for('scorekeepers.show_scorekeeper_types') }}">Show Scorekeeper Types by Year</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('scorekeepers.show_scorekeepers_heatmap') }}">Show Scorekeepers Heatmap</a>
+            </li>
+        </ul>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/scorekeepers/templates/scorekeepers/show-scorekeeper-types-by-year/details.html
+++ b/app/scorekeepers/templates/scorekeepers/show-scorekeeper-types-by-year/details.html
@@ -1,0 +1,164 @@
+{% extends "base.html" %}
+{% set page_title = "Show Scorekeeper Types by Year" %}
+{% block title %}{{ year }} | {{ page_title }} | Scorekeepers{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('scorekeepers.index') }}">Scorekeepers</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('scorekeepers.show_scorekeeper_types') }}">{{ page_title }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ year }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}: {{ year }}</h2>
+
+{% if show_dates and regulars and guests %}
+<p>
+    This chart displays show scorekeeper type (regular scorekeeper or guest
+    scorekeeper) for each show, including regular, Best Of, repeat and repeat
+    Best Of shows.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorway = {{ colorway_light | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro";
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+        colorway = {{ colorway_dark | safe }};
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        colorway = {{ colorway_retro | safe }};
+        fontList = "'IBM Plex Serif', serif";
+    };
+
+    let data = [
+        {
+            x: {{ show_dates | safe }},
+            y: {{ regulars | safe }},
+            name: "Regular",
+            showlegend: true,
+            type: "bar"
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ guests | safe }},
+            name: "Guest",
+            showlegend: true,
+            type: "bar"
+        }
+    ];
+
+    let layout = {
+        autosize: true,
+        barmode: "stack",
+        colorway: colorway,
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 15
+            },
+        },
+        hovermode: "x unified",
+        legend: {
+            font: {
+                color: axisColor,
+                family: fontList,
+                size: 16
+            },
+            traceorder: "normal",
+            orientation: "h",
+            y: 1.025,
+            x: 0,
+        },
+        margin: {
+            l: 60,
+            r: 40,
+            t: 48,
+            b: 90
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: true,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ year | safe }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            nticks: 26,
+            showgrid: false,
+            showspikes: true,
+            spikecolor: axisColor,
+            spikedash: "dot",
+            spikemode: "across",
+            spikethickness: 1,
+            tickangle: -45,
+            tickfont: { size: 13 },
+            title: {
+                font: { size: 18 },
+                text: "Show Date"
+            },
+            type: "category",
+            visible: true
+        },
+        yaxis: {
+            color: axisColor,
+            dtick: 1,
+            fixedrange: true,
+            showline: true,
+            showgrid: true,
+            tickfont: { size: 16 },
+            visible: false
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "show-scprekeeper-types-by-year-{{ year }}",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    Not enough data is available for {{ year }} to generate a graph.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/scorekeepers/templates/scorekeepers/show-scorekeeper-types-by-year/index.html
+++ b/app/scorekeepers/templates/scorekeepers/show-scorekeeper-types-by-year/index.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
-{% set page_title="Show Location Types by Year" %}
-{% block title %}{{ page_title }} | Locations{% endblock %}
+{% set page_title="Show Scorekeeper Types by Year" %}
+{% block title %}{{ page_title }} | Scorekeepers{% endblock %}
 
 {% block content %}
 <nav aria-label="breadcrumb" id="nav-breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('scorekeepers.index') }}">Scorekeepers</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
     </ol>
 </nav>
 
 <h2>{{ page_title }}</h2>
 <p>
-    Choose from one of the years below to view the location type (home, away or
-    home/remote studios) for each show.
+    Choose from one of the years below to view the show scorekeepers type (regular
+    scorekeeper or guest scorekeeper) for each show.
 </p>
 
 <div class="info">
@@ -21,7 +21,7 @@
         <ul class="list-group name-list">
             {% for year in show_years %}
             <li class="list-group-item">
-                <a href="{{ url_for('locations.show_location_types_by_year', year=year) }}">{{ year }}</a>
+                <a href="{{ url_for('scorekeepers.show_scorekeeper_types_by_year', year=year) }}">{{ year }}</a>
             </li>
             {% endfor %}
         </ul>

--- a/app/scorekeepers/templates/scorekeepers/show-scorekeepers-heatmap/graph.html
+++ b/app/scorekeepers/templates/scorekeepers/show-scorekeepers-heatmap/graph.html
@@ -1,0 +1,154 @@
+{% extends "base.html" %}
+{% set page_title="Show Scorekeepers Heatmap" %}
+{% block title %}{{ page_title }} | Scorekeepers{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('scorekeepers.index') }}">Scorekeepers</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+
+{% if years and show_numbers and data %}
+<p>
+    This heatmap chart displays when shows had a regular or a guest scorekeeper
+    broken out by year.
+</p>
+<p>
+    All shows are included, including regular, Best Of, repeat and repeat Best
+    Of shows. Purple or violet denotes shows with a regular scorekeeper and yellow
+    denotes shows with a guest scorekeeper.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorscale = {{ colorscale_hosts_scorekeepers | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro"
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        fontList = "'IBM Plex Serif', serif";
+        colorscale = {{ colorscale_hosts_scorekeepers_retro | safe }};
+    };
+
+    let showNumbers = {{ show_numbers | safe }};
+    let years = {{ years | safe }};
+    let locData = {{ data | safe }};
+
+    let data = [
+        {
+            x: showNumbers,
+            y: years,
+            z: locData,
+            colorbar: {
+                tickfont: {
+                    color: axisColor,
+                    family: fontList,
+                    size: 16
+                }
+            },
+            colorscale: colorscale,
+            hoverongaps: false,
+            hovertemplate: "%{y} Show #%{x}<extra></extra>",
+            showscale: false,
+            type: "heatmap",
+            xgap: 3,
+            ygap: 3,
+            zsmooth: false
+        }
+    ];
+
+    let layout = {
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        margin: {
+            l: 128,
+            r: 64,
+            t: 64,
+            b: 64
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: false,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Show Number"
+            },
+        },
+        yaxis: {
+            color: axisColor,
+            showgrid: false,
+            showline: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Year"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "show-scorekeepers-heatmap",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No scoring data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/shows/templates/shows/all-scores/index.html
+++ b/app/shows/templates/shows/all-scores/index.html
@@ -16,7 +16,7 @@
 </p>
 
 <div class="info">
-    <div class="shows">
+    <div class="pages">
         <ul class="list-group show-list">
             {% for year in show_years %}
             <li class="list-group-item">

--- a/app/shows/templates/shows/counts-by-day-month/index.html
+++ b/app/shows/templates/shows/counts-by-day-month/index.html
@@ -17,7 +17,7 @@
 </p>
 
 <div class="info">
-    <div class="shows">
+    <div class="pages">
         <ul class="list-group show-list">
             <li class="list-group-item">
                 <a href="{{ url_for('shows.counts_by_day_of_month_all') }}">All</a>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -23,10 +23,16 @@
                             <hr>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('hosts.index') }}">Hosts</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('locations.index') }}">Locations</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('panelists.index') }}">Panelists</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('scorekeepers.index') }}">Scorekeepers</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('shows.index') }}">Shows</a>

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -21,6 +21,20 @@
     <div class="pages">
         <ul class="list-group page-list">
             <li class="list-group-item">
+                <h3>Hosts</h3>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('hosts.show_host_types') }}">Show Host Types by Year</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('hosts.show_hosts_heatmap') }}">Show Hosts Heatmap</a>
+            </li>
+        </ul>
+    </div>
+
+    <div class="pages">
+        <ul class="list-group page-list">
+            <li class="list-group-item">
                 <h3>Locations</h3>
             </li>
             <li class="list-group-item">
@@ -63,6 +77,20 @@
             </li>
             <li class="list-group-item">
                 <a href="{{ url_for('panelists.scores_by_appearance') }}">Scores by Appearance</a>
+            </li>
+        </ul>
+    </div>
+
+    <div class="pages">
+        <ul class="list-group page-list">
+            <li class="list-group-item">
+                <h3>Scorekeepers</h3>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('scorekeepers.show_scorekeeper_types') }}">Show Scorekeeper Types by Year</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('scorekeepers.show_scorekeepers_heatmap') }}">Show Scorekeepers Heatmap</a>
             </li>
         </ul>
     </div>

--- a/app/templates/sitemaps/sitemap.xml
+++ b/app/templates/sitemaps/sitemap.xml
@@ -5,6 +5,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("hosts.index") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("locations.index") }}</loc>
     <changefreq>weekly</changefreq>
   </url>
@@ -36,6 +40,12 @@
     <loc>{{ site_url }}{{ url_for("locations.show_location_types") }}</loc>
     <changefreq>weekly</changefreq>
   </url>
+{% for year in show_years %}
+  <url>
+    <loc>{{ site_url }}{{ url_for("locations.show_location_types_by_year", year=year) }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+{% endfor %}
   <url>
     <loc>{{ site_url }}{{ url_for("panelists.index") }}</loc>
     <changefreq>weekly</changefreq>
@@ -70,6 +80,10 @@
     <changefreq>weekly</changefreq>
   </url>
 {% endfor %}
+  <url>
+    <loc>{{ site_url }}{{ url_for("scorekeepers.index") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
   <url>
     <loc>{{ site_url }}{{ url_for("shows.index") }}</loc>
     <changefreq>weekly</changefreq>

--- a/colors.yaml
+++ b/colors.yaml
@@ -77,7 +77,7 @@ colorscale_away:
 
 colorscale_away_retro:
   - [0.0, "#000000"] # Black
-  - [1.0, "#ff66ff"]
+  - [1.0, "#ffff66"]
 
 colorscale_studios:
   - [0.0, "#000000"] # Black
@@ -98,3 +98,11 @@ colorscale_home_away_studios_retro:
   - [0.333333, "#ff66ff"] # Home
   - [0.666667, "#00cc00"] # Home/Remote Studios
   - [1.0, "#000000"] # Black (TBD)
+
+colorscale_hosts_scorekeepers:
+  - [0.0, "#a56eff"] # IBM Purple 50
+  - [1.0, "#f1c21b"] # IBM Alert 30
+
+colorscale_hosts_scorekeepers_retro:
+  - [0.0, "#ff66ff"]
+  - [1.0, "#ffff66"]

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Hosts Module and Blueprint Views."""
+
+import pytest
+from flask.testing import FlaskClient
+from werkzeug.test import TestResponse
+
+
+def test_index(client: FlaskClient) -> None:
+    """Testing hosts.index."""
+    response: TestResponse = client.get("/hosts/")
+    assert response.status_code == 200
+    assert b"Hosts" in response.data
+    assert b"Show Hosts Heatmap" in response.data
+
+
+def test_all_show_hosts_heatmap(client: FlaskClient) -> None:
+    """Testing hosts.show_hosts_heatmap."""
+    response: TestResponse = client.get("/hosts/show-hosts-heatmap")
+    assert response.status_code == 200
+    assert b"Show Hosts Heatmap" in response.data
+    assert b"plotly" in response.data
+
+
+def test_show_host_types(client: FlaskClient) -> None:
+    """Testing hosts.show_host_types."""
+    response: TestResponse = client.get("/hosts/show-host-types-by-year")
+    assert response.status_code == 200
+    assert b"Show Host Types by Year" in response.data
+
+
+@pytest.mark.parametrize("year", [2006, 2020, 2025])
+def test_show_host_types_by_year(client: FlaskClient, year: int) -> None:
+    """Testing hosts.show_host_types_by_year."""
+    response: TestResponse = client.get(f"/hosts/show-host-types-by-year/{year}")
+    assert response.status_code == 200
+    assert b"Show Host Types by Year" in response.data
+    assert b"Regular" in response.data
+    assert b"Guest" in response.data
+    assert b"plotly" in response.data

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Scorekeepers Module and Blueprint Views."""
+
+import pytest
+from flask.testing import FlaskClient
+from werkzeug.test import TestResponse
+
+
+def test_index(client: FlaskClient) -> None:
+    """Testing scorekeepers.index."""
+    response: TestResponse = client.get("/scorekeepers/")
+    assert response.status_code == 200
+    assert b"Scorekeepers" in response.data
+    assert b"Show Scorekeepers Heatmap" in response.data
+
+
+def test_all_show_scorekeepers_heatmap(client: FlaskClient) -> None:
+    """Testing scorekeepers.show_scorekeepers_heatmap."""
+    response: TestResponse = client.get("/scorekeepers/show-scorekeepers-heatmap")
+    assert response.status_code == 200
+    assert b"Show Scorekeepers Heatmap" in response.data
+    assert b"plotly" in response.data
+
+
+def test_show_scorekeeper_types(client: FlaskClient) -> None:
+    """Testing scorekeepers.show_scorekeeper_types."""
+    response: TestResponse = client.get("/scorekeepers/show-scorekeeper-types-by-year")
+    assert response.status_code == 200
+    assert b"Show Scorekeeper Types by Year" in response.data
+
+
+@pytest.mark.parametrize("year", [2006, 2020, 2025])
+def test_show_host_types_by_year(client: FlaskClient, year: int) -> None:
+    """Testing scorekeepers.show_host_types_by_year."""
+    response: TestResponse = client.get(
+        f"/scorekeepers/show-scorekeeper-types-by-year/{year}"
+    )
+    assert response.status_code == 200
+    assert b"Show Scorekeeper Types by Year" in response.data
+    assert b"Regular" in response.data
+    assert b"Guest" in response.data
+    assert b"plotly" in response.data


### PR DESCRIPTION
## Application Changes

- Added "Show Host Types by Year" and "Show Scorekeeper Types by Year" bar charts that plots out each show for a given year and displays one color if a show had a regular host or scorekeeper and another for guest host or scorekeeper
- Added "Show Hosts Heatmap" and "Show Scorekeepers Heatmap" charts that displays whether a show had a regular or a guest host or scorekeeper, respectively
  - Hovering over each block in the heatmap only displays the year and the show number for that year
  - Displaying the show date instead of the show number of a given year leads to issues with the heatmap due to dates not aligning correct and issues with rendering the axis
- Added a new set of colorscales for the "Show Hosts Heatma" and "Show Scorekeepers Heatmap"
- Corrected the `colorscale_away_retro` value for `1.0` to `#ffff66` in `colors.yaml` to match the corresponding default listed in `app/config.py`
- Corrected the HTML class to `pages` for several index pages for consistency