### PR TITLE
New Show Types charts, code cleanup/rework, fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changes
 
+## 3.11.0
+
+### Application Changes
+
+- Added "Show Types by Year" charts that plots every show for a specific year and if it is a regular, Best Of, repeat or a repeat Best Of show.
+- Added "Show Types Heatmap" that plots every show with blocks of various colors to denote regular, Best Of, repeat and repeat Best Of shows.
+  - Hovering over each block in the heatmap only displays the year and the show number for that year
+  - Displaying the show date instead of the show number of a given year leads to issues with the heatmap due to dates not aligning correct and issues with rendering the axis
+- Fixed the padding used at the end of the lists returned in the following functions under `app.reports.location`. The lists should be padded with `None` values rather than zeroes. Padding the lists with zeroes meant that it was hard to discern when the show had aired fewer than 53 shows in a single year.
+  - `retrieve_away_shows_by_year`
+  - `retrieve_away_shows_all_years`
+  - `retrieve_home_shows_by_year`
+  - `retrieve_home_shows_all_years`
+  - `retrieve_home_remote_studios_shows_by_year`
+  - `retrieve_home_remote_studios_shows_all_years`
+- Cleaned up and re-worked some spaghetti code
+- Updated some of the chart descriptions for clarity and accuracy
+
 ## 3.10.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -118,6 +118,12 @@ def create_app():
     app.jinja_env.globals["colorscale_hosts_scorekeepers_retro"] = json.dumps(
         _colors["colorscale_hosts_scorekeepers_retro"]
     )
+    app.jinja_env.globals["colorscale_show_types"] = json.dumps(
+        _colors["colorscale_show_types"]
+    )
+    app.jinja_env.globals["colorscale_show_types_retro"] = json.dumps(
+        _colors["colorscale_show_types_retro"]
+    )
     app.jinja_env.globals["colorscale_retro"] = json.dumps(_colors["colorscale_retro"])
     app.jinja_env.globals["colorway_light"] = json.dumps(_colors["colorway_light"])
     app.jinja_env.globals["colorway_dark"] = json.dumps(_colors["colorway_dark"])

--- a/app/config.py
+++ b/app/config.py
@@ -111,7 +111,7 @@ COLORSCALE_HOME_AWAY_STUDIOS: list[float | str] = [
 ]
 
 COLORSCALE_HOME_AWAY_STUDIOS_RETRO: list[float | str] = [
-    [0.0, "#ffff66"],  # Yello (Away)
+    [0.0, "#ffff66"],  # Yellow (Away)
     [0.333333, "#ff66ff"],  # Home
     [0.666667, "#00cc00"],  # Home/Remote Studios
     [1.0, "#000000"],  # Black (TBD)
@@ -124,6 +124,20 @@ COLORSCALE_HOSTS_SCOREKEEPERS: list[float | str] = [
 COLORSCALE_HOSTS_SCOREKEEPERS_RETRO: list[float | str] = [
     [0.0, "#ff66ff"],
     [1.0, "#ffff66"],
+]
+
+COLORSCALE_SHOW_TYPES: list[float | str] = [
+    [0.0, "#a56eff"],  # IBM Purple 50 (Regular)
+    [0.333333, "#f1c21b"],  # IBM Alert 30 (Best Of)
+    [0.666667, "#007d79"],  # IBM Teal 60 (Repeat)
+    [1.0, "#da1e28"],  # IBM Red 50 (Repeat Best Of)
+]
+
+COLORSCALE_SHOW_TYPES_RETRO: list[float | str] = [
+    [0.0, "#ff66ff"],  # Regular
+    [0.333333, "#ffff66"],  # Yellow (Best Of)
+    [0.666667, "#00cc00"],  # Repeat
+    [1.0, "#ff0000"],  # Black (Repeat Best Of)
 ]
 
 
@@ -176,6 +190,12 @@ def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
                 "colorscale_hosts_scorekeepers_retro",
                 COLORSCALE_HOSTS_SCOREKEEPERS_RETRO,
             ),
+            "colorscale_show_types": colors_config.get(
+                "colorscale_show_types", COLORSCALE_SHOW_TYPES
+            ),
+            "colorscale_show_types_retro": colors_config.get(
+                "colorscale_show_types_retro", COLORSCALE_SHOW_TYPES_RETRO
+            ),
         }
     else:
         _config = {
@@ -197,6 +217,8 @@ def load_colors(colors_file_path: str = "colors.yaml") -> dict[str, list[str]]:
             "colorscale_home_away_studios_retro": COLORSCALE_HOME_AWAY_STUDIOS_RETRO,
             "colorscale_hosts_scorekeepers": COLORSCALE_HOSTS_SCOREKEEPERS,
             "colorscale_hosts_scorekeepers_retro": COLORSCALE_HOSTS_SCOREKEEPERS_RETRO,
+            "colorscale_show_types": COLORSCALE_SHOW_TYPES,
+            "colorscale_show_types_retro": COLORSCALE_SHOW_TYPES_RETRO,
         }
 
     return _config

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -69,7 +69,7 @@ def show_host_types_by_year(year: int) -> str:
     if not _data:
         return redirect_url(url_for("hosts.show_host_types"))
 
-    if "show_dates" in _data and "regulars" in _data and "guests" in _data:
+    if {"show_dates", "regulars", "guests"} <= set(_data):
         return render_template(
             "hosts/show-host-types-by-year/details.html",
             year=year,

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -198,13 +198,7 @@ def show_location_types_by_year(year: int) -> str:
     if not _data:
         return redirect_url(url_for("locations.show_location_types"))
 
-    if (
-        "show_dates" in _data
-        and "home" in _data
-        and "away" in _data
-        and "studios" in _data
-        and "tbd_na" in _data
-    ):
+    if {"show_dates", "home", "away", "studios", "tbd_na"} <= set(_data):
         return render_template(
             "locations/show-location-types-by-year/details.html",
             year=year,

--- a/app/locations/templates/locations/all-locations-shows-heatmap/graph.html
+++ b/app/locations/templates/locations/all-locations-shows-heatmap/graph.html
@@ -14,15 +14,16 @@
 
 {% if years and show_numbers and data %}
 <p>
-    This heatmap chart displays when shows that were recorded at home (any venue
-    or studio located in Chicago, Illinois), away and from home/remote studios
-    broken out by year.
+    This heatmap chart displays that shows the location type for each show
+    broken out by year. All shows are represented in the heatmap, including
+    regular, Best Of and repeat Best Of shows.
 </p>
 <p>
     All shows are included, including regular, Best Of, repeat and repeat Best
-    Of shows. Purple or violet denotes home shows, yellow denotes away shows,
-    green denotes home/remote studios shows, and black denotes a location that
-    is to be determined or is not available.
+    Of shows. Purple or violet blocks denote home shows (recorded in Chicago,
+    Illinois), yellow blocks denote away shows (recorded outside of Chicago),
+    green blocks denote home/remote studios shows, and black blocks denote a
+    location that has yet to be determined or is not available.
 </p>
 
 <div class="info py-2">

--- a/app/reports/hosts/host_years.py
+++ b/app/reports/hosts/host_years.py
@@ -55,7 +55,7 @@ def retrieve_host_types_by_year(year: int) -> list[int] | None:
 
 def retrieve_host_types_by_year_with_dates(
     year: int,
-) -> dict[str, list[int | str]] | None:
+) -> dict[str, list[int | None]] | None:
     """Retrieve all shows for a given year with values for normal or guest hosts.
 
     The dictionary contains two lists, one with show dates and a list each

--- a/app/reports/location/home_vs_away_year.py
+++ b/app/reports/location/home_vs_away_year.py
@@ -227,12 +227,12 @@ def retrieve_home_away_studios_shows_by_year(
     }
 
 
-def retrieve_home_shows_by_year(year: int) -> list[int] | None:
+def retrieve_home_shows_by_year(year: int) -> list[int | None] | None:
     """Retrieve a list of all shows noted as home shows for a given year.
 
     The list contains either zeroes or ones, where ones denote shows
     recorded in Chicago, IL. The returned list will be padded out with
-    zeroes in order to have 53 items.
+    None values in order to have 53 items.
     """
     database_connection = connect(**current_app.config["database"])
 
@@ -273,7 +273,7 @@ def retrieve_home_shows_by_year(year: int) -> list[int] | None:
     return _shows
 
 
-def retrieve_home_shows_all_years() -> dict[int, list[int]] | None:
+def retrieve_home_shows_all_years() -> dict[int, list[int | None]] | None:
     """Retrieves a dictionary containing shows noted as home shows.
 
     Dictionary key is the year and each key value is a list of either
@@ -291,13 +291,13 @@ def retrieve_home_shows_all_years() -> dict[int, list[int]] | None:
     return _info
 
 
-def retrieve_away_shows_by_year(year: int) -> list[int] | None:
+def retrieve_away_shows_by_year(year: int) -> list[int | None] | None:
     """Retrieve a list of all shows noted as away shows for a given year.
 
     The list contains either zeroes or ones, where ones denote shows
     recorded away from Chicago, IL, but exclude shows with Home/Remote
     Studios as their location. The returned list will be padded out with
-    zeroes in order to have 53 items.
+    None values in order to have 53 items.
     """
     database_connection = connect(**current_app.config["database"])
 
@@ -339,12 +339,12 @@ def retrieve_away_shows_by_year(year: int) -> list[int] | None:
 
     _shows_len = len(_shows)
     if _shows_len < _MAX_SHOWS_PER_YEAR:
-        _shows = _shows + ([0] * (_MAX_SHOWS_PER_YEAR - _shows_len))
+        _shows = _shows + ([None] * (_MAX_SHOWS_PER_YEAR - _shows_len))
 
     return _shows
 
 
-def retrieve_away_shows_all_years() -> dict[int, list[int]] | None:
+def retrieve_away_shows_all_years() -> dict[int, list[int | None]] | None:
     """Retrieves a dictionary containing shows noted as away shows.
 
     Dictionary key is the year and each key value is a list of either
@@ -363,12 +363,12 @@ def retrieve_away_shows_all_years() -> dict[int, list[int]] | None:
     return _info
 
 
-def retrieve_home_remote_studios_shows_by_year(year: int) -> list[int] | None:
+def retrieve_home_remote_studios_shows_by_year(year: int) -> list[int | None] | None:
     """Retrieve a list of all shows noted as Home/Remote Studio shows for a given year.
 
     The list contains either zeroes or ones, where ones denote shows
     recorded from Home/Remote Studios. The returned list will be padded
-    out with zeroes in order to have 53 items.
+    out with None values in order to have 53 items.
     """
     database_connection = connect(**current_app.config["database"])
 
@@ -402,12 +402,14 @@ def retrieve_home_remote_studios_shows_by_year(year: int) -> list[int] | None:
 
     _shows_len = len(_shows)
     if _shows_len < _MAX_SHOWS_PER_YEAR:
-        _shows = _shows + ([0] * (_MAX_SHOWS_PER_YEAR - _shows_len))
+        _shows = _shows + ([None] * (_MAX_SHOWS_PER_YEAR - _shows_len))
 
     return _shows
 
 
-def retrieve_home_remote_studios_shows_all_years() -> dict[int, list[int]] | None:
+def retrieve_home_remote_studios_shows_all_years() -> (
+    dict[int, list[int | None]] | None
+):
     """Retrieves a dictionary containing shows noted as Home/Remote Studio shows.
 
     Dictionary key is the year and each key value is a list of either

--- a/app/reports/scorekeepers/scorekeeper_years.py
+++ b/app/reports/scorekeepers/scorekeeper_years.py
@@ -57,7 +57,7 @@ def retrieve_scorekeeper_types_by_year(year: int) -> list[int] | None:
 
 def retrieve_scorekeeper_types_by_year_with_dates(
     year: int,
-) -> dict[str, list[int | str]] | None:
+) -> dict[str, list[int | None]] | None:
     """Retrieve all shows for a given year with values for normal or guest scorekeepers.
 
     The dictionary contains two lists, one with show dates and a list each

--- a/app/reports/show/types_by_year.py
+++ b/app/reports/show/types_by_year.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2018-2025 Linh Pham
+# graphs.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Show Types by Year Retrieval Functions."""
+
+from flask import current_app
+from mysql.connector import connect
+
+from app.reports.location.home_vs_away_year import _MAX_SHOWS_PER_YEAR
+from app.reports.show.utility import retrieve_show_years
+
+
+def retrieve_show_types_by_year(year: int) -> list[int] | None:
+    """Retrieve a list of all shows with corresponding values for show types.
+
+    The list contains zeroes for regular shows, ones for Best Of shows,
+    twos for repeat shows, and threes for repeat Best Of shows. The
+    returned list will be padded out with None in order to have 53
+    items.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years: list[int] | None = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT bestof, repeatshowid FROM ww_shows
+        WHERE YEAR(showdate) = %s
+        ORDER BY showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _shows: list[int | None] = []
+    for row in results:
+        best_of = bool(row[0])
+        repeat = bool(row[1])
+
+        if best_of and repeat:
+            _shows.append(3)
+        elif repeat:
+            _shows.append(2)
+        elif best_of:
+            _shows.append(1)
+        elif not best_of and not repeat:
+            _shows.append(0)
+
+    _shows_len: int = len(_shows)
+    if _shows_len < _MAX_SHOWS_PER_YEAR:
+        _shows = _shows + ([None] * (_MAX_SHOWS_PER_YEAR - _shows_len))
+
+    return _shows
+
+
+def retrieve_show_types_by_year_with_dates(
+    year: int,
+) -> dict[str, list[int | None]] | None:
+    """Retrieves all shows for a given year with values denoting show types.
+
+    The returned dictionary contains a list of show dates and a list
+    of each regular, Best Of, repeat and repeat Best Of shows where
+    one denotes the corresponding show type.
+    """
+    database_connection = connect(**current_app.config["database"])
+
+    _years = retrieve_show_years(reverse_order=False)
+    if not _years or year not in _years:
+        return None
+
+    query = """
+        SELECT showdate, bestof, repeatshowid FROM ww_shows
+        WHERE YEAR(showdate) = %s
+        ORDER BY showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query, (year,))
+    results = cursor.fetchall()
+    cursor.close()
+    database_connection.close()
+
+    if not results:
+        return None
+
+    _show_dates = []
+    _regulars = []
+    _best_ofs = []
+    _repeats = []
+    _repeat_best_ofs = []
+
+    for row in results:
+        best_of = bool(row[1])
+        repeat = bool(row[2])
+
+        _show_dates.append(row[0].isoformat())
+        if best_of and repeat:
+            _regulars.append(None)
+            _best_ofs.append(None)
+            _repeats.append(None)
+            _repeat_best_ofs.append(1)
+        elif best_of:
+            _regulars.append(None)
+            _best_ofs.append(1)
+            _repeats.append(None)
+            _repeat_best_ofs.append(None)
+        elif repeat:
+            _regulars.append(None)
+            _best_ofs.append(None)
+            _repeats.append(1)
+            _repeat_best_ofs.append(None)
+        elif not best_of and not repeat:
+            _regulars.append(1)
+            _best_ofs.append(None)
+            _repeats.append(None)
+            _repeat_best_ofs.append(None)
+
+    return {
+        "show_dates": _show_dates,
+        "regulars": _regulars,
+        "best_ofs": _best_ofs,
+        "repeats": _repeats,
+        "repeat_best_ofs": _repeat_best_ofs,
+    }
+
+
+def retrieve_show_types_all_years() -> dict[int, list[int | None]] | None:
+    """Retrieves a dictionary containing show types across all years.
+
+    Dictionary key is the year and the key value is a list of zeroes,
+    ones, twos and threes for regular, Best Of, repeat and repeat Best
+    Of shows respectively. Lists are padded with None values at the end
+    to have consistent list length.
+    """
+    _years: list[int] | None = retrieve_show_years(reverse_order=False)
+
+    if not _years:
+        return None
+
+    _info = {}
+    for year in _years:
+        _info[year] = retrieve_show_types_by_year(year=year)
+
+    return _info

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -69,7 +69,7 @@ def show_scorekeeper_types_by_year(year: int) -> str:
     if not _data:
         return redirect_url(url_for("scorekeepers.show_scorekeeper_types"))
 
-    if "show_dates" in _data and "regulars" in _data and "guests" in _data:
+    if {"show_dates", "regulars", "guests"} <= set(_data):
         return render_template(
             "scorekeepers/show-scorekeeper-types-by-year/details.html",
             year=year,

--- a/app/shows/templates/shows/index.html
+++ b/app/shows/templates/shows/index.html
@@ -42,6 +42,12 @@
             <li class="list-group-item">
                 <a href="{{ url_for('shows.panel_gender_mix') }}">Panel Gender Mix</a>
             </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('shows.show_types') }}">Show Types by Year</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('shows.show_types_heatmap') }}">Show Types Heatmap</a>
+            </li>
         </ul>
     </div>
 </div>

--- a/app/shows/templates/shows/show-types-by-year/details.html
+++ b/app/shows/templates/shows/show-types-by-year/details.html
@@ -1,0 +1,177 @@
+{% extends "base.html" %}
+{% set page_title = "Show Types by Year" %}
+{% block title %}{{ year }} | {{ page_title }} | Shows{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.show_types') }}">{{ page_title }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ year }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}: {{ year }}</h2>
+
+{% if show_dates and regulars and best_ofs and repeats and repeat_best_ofs %}
+<p>
+    This chart displays each show type (regular, Best Ofs, repeats and repeat
+    Best Ofs) for all shows from {{ year }}.
+</p>
+
+<div class="info py-2">
+    <div id="ww-chart"></div>
+</div>
+
+<script>
+    // Set default colors
+    let axisColor = "#000";
+    let backgroundColor = "#fff";
+    let colorway = {{ colorway_light | safe }};
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
+    const getStoredTheme = () => localStorage.getItem("theme");
+    const storedTheme = getStoredTheme();
+    let lightMode = storedTheme === "light" || ((storedTheme === "light" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches));
+    let darkMode = storedTheme === "dark" || ((storedTheme === "dark" || storedTheme === "auto") && (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches));
+    let retroMode = storedTheme === "retro";
+    if (darkMode) {
+        axisColor = "#fff";
+        backgroundColor = "#262626"; // IBM Gray 100
+        colorway = {{ colorway_dark | safe }};
+    } else if (retroMode) {
+        backgroundColor = "#c0c0c0";
+        colorway = {{ colorway_retro | safe }};
+        fontList = "'IBM Plex Serif', serif";
+    };
+
+    let data = [
+        {
+            x: {{ show_dates | safe }},
+            y: {{ regulars | safe }},
+            name: "Regulars",
+            showlegend: true,
+            type: "bar"
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ best_ofs | safe }},
+            name: "Best Ofs",
+            showlegend: true,
+            type: "bar"
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ repeats | safe }},
+            name: "Repeats",
+            showlegend: true,
+            type: "bar"
+        },
+        {
+            x: {{ show_dates | safe }},
+            y: {{ repeat_best_ofs | safe }},
+            name: "Repeat Best Ofs",
+            showlegend: true,
+            type: "bar"
+        },
+    ];
+
+    let layout = {
+        autosize: true,
+        barmode: "stack",
+        colorway: colorway,
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 15
+            },
+        },
+        hovermode: "x unified",
+        legend: {
+            font: {
+                color: axisColor,
+                family: fontList,
+                size: 16
+            },
+            traceorder: "normal",
+            orientation: "h",
+            y: 1.025,
+            x: 0,
+        },
+        margin: {
+            l: 60,
+            r: 40,
+            t: 48,
+            b: 90
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: true,
+        title: {
+            automargin: true,
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            pad: {
+                t: 6
+            },
+            text: "{{ page_title }}: {{ year | safe }}",
+            x: 0.01
+        },
+        xaxis: {
+            color: axisColor,
+            nticks: 26,
+            showgrid: false,
+            showspikes: true,
+            spikecolor: axisColor,
+            spikedash: "dot",
+            spikemode: "across",
+            spikethickness: 1,
+            tickangle: -45,
+            tickfont: { size: 13 },
+            title: {
+                font: { size: 18 },
+                text: "Show Date"
+            },
+            type: "category",
+            visible: true
+        },
+        yaxis: {
+            color: axisColor,
+            dtick: 1,
+            fixedrange: true,
+            showline: true,
+            showgrid: true,
+            tickfont: { size: 16 },
+            visible: false
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "autoScale2d",
+            "lasso2d",
+            "select2d",
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "show-types-by-year-{{ year }}",
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    Not enough data is available for {{ year }} to generate a graph.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/app/shows/templates/shows/show-types-by-year/index.html
+++ b/app/shows/templates/shows/show-types-by-year/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% set page_title="Show Types by Year" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<h2>{{ page_title }}</h2>
+<p>
+    This chart displays each show type (regular, Best Ofs, repeats and repeat
+    Best Ofs) for all shows for a specific year.
+</p>
+
+<div class="info">
+    <div class="pages">
+        <ul class="list-group name-list">
+            {% for year in show_years %}
+            <li class="list-group-item">
+                <a href="{{ url_for('shows.show_types_by_year', year=year) }}">{{ year }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/shows/templates/shows/show-types-heatmap/graph.html
+++ b/app/shows/templates/shows/show-types-heatmap/graph.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% set page_title="Away Shows Heatmap" %}
-{% block title %}{{ page_title }} | Locations{% endblock %}
+{% set page_title="Show Types Heatmap" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <nav aria-label="breadcrumb" id="nav-breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
     </ol>
 </nav>
@@ -14,13 +14,13 @@
 
 {% if years and show_numbers and data %}
 <p>
-    This heatmap chart displays when shows that were recorded away from their
-    home (any venue or studio located in Chicago, Illinois), broken down by year.
-    All shows are represented in the heatmap, including regular, Best Of, repeat,
-    and repeat Best Of shows.
+    This heatmap chart displays the show type (regular, Best Of, repeat and
+    repeat Best Of) for each show, broken out by year.
 </p>
 <p>
-    Yellow blocks denote away shows
+    Purple or violet blocks denote regular shows, yellow blocks denote Best Of
+    shows, green blocks denote repeat shows and red blocks denote repeat
+    Best Of shows.
 </p>
 
 <div class="info py-2">
@@ -31,7 +31,7 @@
     // Set default colors and font list
     let axisColor = "#000";
     let backgroundColor = "#fff";
-    let colorscale = {{ colorscale_away | safe }};
+    colorscale = {{ colorscale_show_types | safe }};
     let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
 
     // Change colors if in dark mode (stored theme overrides prefers-color-scheme)
@@ -46,18 +46,18 @@
     } else if (retroMode) {
         backgroundColor = "#c0c0c0";
         fontList = "'IBM Plex Serif', serif";
-        colorscale = {{ colorscale_away_retro | safe }};
+        colorscale = {{ colorscale_show_types_retro | safe }};
     };
 
     let showNumbers = {{ show_numbers | safe }};
     let years = {{ years | safe }};
-    let locData = {{ data | safe }};
+    let showData = {{ data | safe }};
 
     let data = [
         {
             x: showNumbers,
             y: years,
-            z: locData,
+            z: showData,
             colorbar: {
                 tickfont: {
                     color: axisColor,
@@ -136,7 +136,7 @@
         ],
         responsive: true,
         toImageButtonOptions: {
-            filename: "away-shows-heatmap",
+            filename: "show-types-heatmap",
             height: 800,
             scale: 1,
             width: 1200

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -124,6 +124,12 @@
             <li class="list-group-item">
                 <a href="{{ url_for('shows.panel_gender_mix') }}">Panel Gender Mix</a>
             </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('shows.show_types') }}">Show Types by Year</a>
+            </li>
+            <li class="list-group-item">
+                <a href="{{ url_for('shows.show_types_heatmap') }}">Show Types Heatmap</a>
+            </li>
         </ul>
     </div>
 </div>

--- a/app/templates/sitemaps/sitemap.xml
+++ b/app/templates/sitemaps/sitemap.xml
@@ -146,4 +146,18 @@
     <loc>{{ site_url }}{{ url_for("shows.panel_gender_mix") }}</loc>
     <changefreq>weekly</changefreq>
   </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("shows.show_types") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+{% for year in show_years %}
+  <url>
+    <loc>{{ site_url }}{{ url_for("shows.show_types_by_year", year=year) }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+{% endfor %}
+  <url>
+    <loc>{{ site_url }}{{ url_for("shows.show_types_heatmap") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.10.0"
+APP_VERSION = "3.11.0"

--- a/colors.yaml
+++ b/colors.yaml
@@ -94,7 +94,7 @@ colorscale_home_away_studios:
   - [1.0, "#000000"] # Black (TBD)
 
 colorscale_home_away_studios_retro:
-  - [0.0, "#ffff66"] # Yello (Away)
+  - [0.0, "#ffff66"] # Yellow (Away)
   - [0.333333, "#ff66ff"] # Home
   - [0.666667, "#00cc00"] # Home/Remote Studios
   - [1.0, "#000000"] # Black (TBD)
@@ -106,3 +106,15 @@ colorscale_hosts_scorekeepers:
 colorscale_hosts_scorekeepers_retro:
   - [0.0, "#ff66ff"]
   - [1.0, "#ffff66"]
+
+colorscale_show_types:
+  - [0.0, "#a56eff"] # IBM Purple 50 (Regular)
+  - [0.333333, "#f1c21b"] # IBM Alert 30 (Best Of)
+  - [0.666667, "#007d79"] # IBM Magenta 40 (Repeat)
+  - [1.0, "#da1e28"] # IBM Red 50 (Repeat Best Of)
+
+colorscale_show_types_retro:
+  - [0.0, "#ff66ff"] # Regular
+  - [0.333333, "#ffff66"] # Yellow (Best Of)
+  - [0.666667, "#00cc00"] # Repeat
+  - [1.0, "#ff0000"] # Red (Repeat Best Of)

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -137,3 +137,30 @@ def test_panel_gender_mix(client: FlaskClient) -> None:
     assert b"Panel Gender Mix" in response.data
     assert b"2W / 1M" in response.data
     assert b"Year" in response.data
+
+
+def test_show_types(client: FlaskClient) -> None:
+    """Testing shows.show_types."""
+    response: TestResponse = client.get("/shows/show-types-by-year")
+    assert response.status_code == 200
+    assert b"Show Types by Year" in response.data
+    assert b"Best Ofs" in response.data
+
+
+@pytest.mark.parametrize("year", [1998, 2006, 2025])
+def test_show_types_by_year(client: FlaskClient, year: int) -> None:
+    """Testing shows.show_types_by_year."""
+    response: TestResponse = client.get(f"/shows/show-types-by-year/{year}")
+    assert response.status_code == 200
+    assert b"Show Types by Year" in response.data
+    assert b"Best Ofs" in response.data
+    assert b"plotly" in response.data
+
+
+def test_show_types_heatmap(client: FlaskClient) -> None:
+    """Testing shows.show_types_heatmap."""
+    response: TestResponse = client.get("/shows/show-types-heatmap/")
+    assert response.status_code == 200
+    assert b"Show Types Heatmap" in response.data
+    assert b"Best Of" in response.data
+    assert b"plotly" in response.data


### PR DESCRIPTION
## Application Changes

- Added "Show Types by Year" charts that plots every show for a specific year and if it is a regular, Best Of, repeat or a repeat Best Of show.
- Added "Show Types Heatmap" that plots every show with blocks of various colors to denote regular, Best Of, repeat and repeat Best Of shows.
  - Hovering over each block in the heatmap only displays the year and the show number for that year
  - Displaying the show date instead of the show number of a given year leads to issues with the heatmap due to dates not aligning correct and issues with rendering the axis
- Fixed the padding used at the end of the lists returned in the following functions under `app.reports.location`. The lists should be padded with `None` values rather than zeroes. Padding the lists with zeroes meant that it was hard to discern when the show had aired fewer than 53 shows in a single year.
  - `retrieve_away_shows_by_year`
  - `retrieve_away_shows_all_years`
  - `retrieve_home_shows_by_year`
  - `retrieve_home_shows_all_years`
  - `retrieve_home_remote_studios_shows_by_year`
  - `retrieve_home_remote_studios_shows_all_years`
- Cleaned up and re-worked some spaghetti code
- Updated some of the chart descriptions for clarity and accuracy