### PR TITLE
Fix divide-by-zero error in Bluff vs NMJ win ratios chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 3.11.1
+
+### Application Changes
+
+- Fixed an uncaught divide-by-zero error that occurs when there aren't any Bluff the Listener or Not My Job data for a given year for the "Not My Job vs Bluff the Listener Win Ratios" chart
+
 ## 3.11.0
 
 ### Application Changes

--- a/app/reports/show/guests_vs_bluffs.py
+++ b/app/reports/show/guests_vs_bluffs.py
@@ -115,15 +115,18 @@ def retrieve_not_my_job_win_rate_by_year(
                 elif result["guestscore"] < 2 and not bool(result["exception"]):
                     best_of_only_guest_losses += 1
 
-    win_ratio = round(
-        100
-        * (
-            (count_guest_wins + best_of_only_guest_wins)
-            / (count_all_guest_scores + len(best_of_only_guest_ids))
-        ),
-        5,
-    )
-    return win_ratio
+    if count_all_guest_scores or best_of_only_guest_ids:
+        win_ratio = round(
+            100
+            * (
+                (count_guest_wins + best_of_only_guest_wins)
+                / (count_all_guest_scores + len(best_of_only_guest_ids))
+            ),
+            5,
+        )
+        return win_ratio
+
+    return 0
 
 
 def retrieve_bluff_win_rate_by_year(
@@ -178,5 +181,8 @@ def retrieve_bluff_win_rate_by_year(
 
     count_chosen_correct = result[0]
 
-    correct_ratio = round(100 * (count_chosen_correct / count_unique_bluffs), 5)
-    return correct_ratio
+    if count_unique_bluffs:
+        correct_ratio = round(100 * (count_chosen_correct / count_unique_bluffs), 5)
+        return correct_ratio
+
+    return 0

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.11.0"
+APP_VERSION = "3.11.1"


### PR DESCRIPTION
## Application Changes

- Fixed an uncaught divide-by-zero error that occurs when there aren't any Bluff the Listener or Not My Job data for a given year for the "Not My Job vs Bluff the Listener Win Ratios" chart