### PR TITLE
Update Guest Host/Scorekeeper Counts by Year Title, Upgrade Plotly.js to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 3.13.1
+
+### Application Changes
+
+- Changed the title of "Guest Host Counts by Year" and "Guest Scorekeeper Counts by Year" to "Guest Host Appearance Counts by Year" and "Guest Scorekeeper Appearance Counts by Year" to clarify the purpose of the charts
+
 ## 3.13.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Changed the title of "Guest Host Counts by Year" and "Guest Scorekeeper Counts by Year" to "Guest Host Appearance Counts by Year" and "Guest Scorekeeper Appearance Counts by Year" to clarify the purpose of the charts
 
+### Component Changes
+
+- Upgraded Plotly.js from 3.3.1 to 3.4.0
+
 ## 3.13.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Changed the title of "Guest Host Counts by Year" and "Guest Scorekeeper Counts by Year" to "Guest Host Appearance Counts by Year" and "Guest Scorekeeper Appearance Counts by Year" to clarify the purpose of the charts
 
+### Development Changes
+
+- Simplified the `runner.sh` and `runner-remote.sh` scripts used to run the Flask application for local development and testing
+
 ### Component Changes
 
 - Upgraded Plotly.js from 3.3.1 to 3.4.0

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -24,7 +24,7 @@ def index() -> str:
 
 @blueprint.route("/guest-host-counts-by-year")
 def guest_host_counts_by_year() -> str:
-    """View: Guest Host Counts by Year."""
+    """View: Guest Host Appearance Counts by Year."""
     _counts = host_years.retrieve_guest_host_counts_by_year()
 
     if not _counts:

--- a/app/hosts/templates/hosts/guest-host-counts-by-year/graph.html
+++ b/app/hosts/templates/hosts/guest-host-counts-by-year/graph.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Guest Host Counts by Year" %}
+{% set page_title = "Guest Host Appearance Counts by Year" %}
 {% block title %}{{ page_title }} | Hosts{% endblock %}
 
 {% block content %}

--- a/app/hosts/templates/hosts/index.html
+++ b/app/hosts/templates/hosts/index.html
@@ -19,7 +19,7 @@
     <div class="pages">
         <ul class="list-group page-list">
             <li class="list-group-item">
-                <a href="{{ url_for('hosts.guest_host_counts_by_year') }}">Guest Hosts Counts by Year</a>
+                <a href="{{ url_for('hosts.guest_host_counts_by_year') }}">Guest Hosts Apperance Counts by Year</a>
             </li>
             <li class="list-group-item">
                 <a href="{{ url_for('hosts.show_host_types') }}">Show Host Types by Year</a>

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -24,7 +24,7 @@ def index() -> str:
 
 @blueprint.route("/guest-scorekeeper-counts-by-year")
 def guest_scorekeeper_counts_by_year() -> str:
-    """View: Guest Scorekeeper Counts by Year."""
+    """View: Guest Scorekeeper Appearance Counts by Year."""
     _counts = scorekeeper_years.retrieve_guest_scorekeeper_counts_by_year()
 
     if not _counts:

--- a/app/scorekeepers/templates/scorekeepers/guest-scorekeeper-counts-by-year/graph.html
+++ b/app/scorekeepers/templates/scorekeepers/guest-scorekeeper-counts-by-year/graph.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Guest Scorekeeper Counts by Year" %}
+{% set page_title = "Guest Scorekeeper Appearance Counts by Year" %}
 {% block title %}{{ page_title }} | Scorekeepers{% endblock %}
 
 {% block content %}

--- a/app/scorekeepers/templates/scorekeepers/index.html
+++ b/app/scorekeepers/templates/scorekeepers/index.html
@@ -19,7 +19,7 @@
     <div class="pages">
         <ul class="list-group page-list">
             <li class="list-group-item">
-                <a href="{{ url_for('scorekeepers.guest_scorekeeper_counts_by_year') }}">Guest Scorekeeper Counts by Year</a>
+                <a href="{{ url_for('scorekeepers.guest_scorekeeper_counts_by_year') }}">Guest Scorekeeper Appearance Counts by Year</a>
             </li>
             <li class="list-group-item">
                 <a href="{{ url_for('scorekeepers.show_scorekeeper_types') }}">Show Scorekeeper Types by Year</a>

--- a/app/static/js/app-code.js
+++ b/app/static/js/app-code.js
@@ -1,6 +1,6 @@
 /*!
  * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)
- * Copyright 2011-2024 The Bootstrap Authors, Linh Pham
+ * Copyright 2011-2026 The Bootstrap Authors, Linh Pham
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  */
 

--- a/app/static/js/plotly.min.js
+++ b/app/static/js/plotly.min.js
@@ -1,1 +1,1 @@
-plotly-3.3.1.min.js
+plotly-3.4.0.min.js

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Graphs Site."""
 
-APP_VERSION = "3.13.0"
+APP_VERSION = "3.13.1"

--- a/runner-remote.sh
+++ b/runner-remote.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-# Shell script used to start up Flask for local development and testing
-export FLASK_APP=app
-export FLASK_DEBUG=1
-export FLASK_RUN_PORT=8000
-. venv/bin/activate
-flask run --host=0.0.0.0
+# Shell script used to start up Flask for local development and testing with
+# remote access
+#
+# Requires a virtual environment (venv) created as venv and all
+# dependencies installed.
+
+FLASK_APP=app FLASK_DEBUG=1 FLASK_RUN_PORT=8000 venv/bin/flask run --host=0.0.0.0

--- a/runner.sh
+++ b/runner.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Shell script used to start up Flask for local development and testing
-export FLASK_APP=app
-export FLASK_DEBUG=1
-export FLASK_RUN_PORT=8000
-. venv/bin/activate
-flask run
+#
+# Requires a virtual environment (venv) created as venv and all
+# dependencies installed.
+
+FLASK_APP=app FLASK_DEBUG=1 FLASK_RUN_PORT=8000 venv/bin/flask run

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -22,7 +22,7 @@ def test_guest_host_counts_by_year(client: FlaskClient) -> None:
     """Testing hosts.guest_host_counts_by_year."""
     response: TestResponse = client.get("/hosts/guest-host-counts-by-year")
     assert response.status_code == 200
-    assert b"Guest Host Counts by Year" in response.data
+    assert b"Guest Host Appearance Counts by Year" in response.data
     assert b"plotly" in response.data
 
 

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -24,7 +24,7 @@ def test_guest_scorekeeper_counts_by_year(client: FlaskClient) -> None:
         "/scorekeepers/guest-scorekeeper-counts-by-year"
     )
     assert response.status_code == 200
-    assert b"Guest Scorekeeper Counts by Year" in response.data
+    assert b"Guest Scorekeeper Appearance Counts by Year" in response.data
     assert b"plotly" in response.data
 
 


### PR DESCRIPTION
## Application Changes

- Changed the title of "Guest Host Counts by Year" and "Guest Scorekeeper Counts by Year" to "Guest Host Appearance Counts by Year" and "Guest Scorekeeper Appearance Counts by Year" to clarify the purpose of the charts

## Development Changes

- Simplified the `runner.sh` and `runner-remote.sh` scripts used to run the Flask application for local development and testing

## Component Changes

- Upgraded Plotly.js from 3.3.1 to 3.4.0