### PR TITLE
Include mention of Universal FOSS Exception for MySQL Connector/Python in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you would like to help sponsor the continued development and maintenance of t
 
 This web application is licensed under the terms of the [Apache License 2.0](./LICENSE), unless otherwise noted.
 
-Although this project interfaces with [MySQL Connector/Python](https://github.com/mysql/mysql-connector-python), licensed under version 2 of the GNU General Public License (GPLv2) and is also subject to the terms included in [Universal FOSS Exception, version 1.0](https://oss.oracle.com/licenses/universal-foss-exception/). The exception permits this library to be licensed under an OSI-approved or a license categorized as "free" by the Freedom Software Foundation (FSF), such as Apache License 2.0.
+Although this project interfaces with [MySQL Connector/Python](https://github.com/mysql/mysql-connector-python), licensed under version 2 of the GNU General Public License (GPLv2) and is also subject to the terms included in [Universal FOSS Exception, version 1.0](https://oss.oracle.com/licenses/universal-foss-exception/). The exception permits this library to be licensed under an OSI-approved or a license categorized as "free" by the Free Software Foundation (FSF), such as Apache License 2.0.
 
 The included version 2 of the [wwdtm-theme](https://github.com/questionlp/wwdtm-theme/tree/v2) submodule is licensed under the terms of the [MIT License](https://github.com/questionlp/wwdtm-theme/blob/v2/LICENSE), unless otherwise noted.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ If you would like to help sponsor the continued development and maintenance of t
 
 This web application is licensed under the terms of the [Apache License 2.0](./LICENSE), unless otherwise noted.
 
+Although this project interfaces with [MySQL Connector/Python](https://github.com/mysql/mysql-connector-python), licensed under version 2 of the GNU General Public License (GPLv2) and is also subject to the terms included in [Universal FOSS Exception, version 1.0](https://oss.oracle.com/licenses/universal-foss-exception/). The exception permits this library to be licensed under an OSI-approved or a license categorized as "free" by the Freedom Software Foundation (FSF), such as Apache License 2.0.
+
+The included version 2 of the [wwdtm-theme](https://github.com/questionlp/wwdtm-theme/tree/v2) submodule is licensed under the terms of the [MIT License](https://github.com/questionlp/wwdtm-theme/blob/v2/LICENSE), unless otherwise noted.
+
 [Bootstrap](https://github.com/twbs/bootstrap) and [Bootstrap Icons](https://github.com/twbs/icons) are both licensed under the terms of the [MIT License](https://github.com/twbs/bootstrap/blob/main/LICENSE).
 
 [IBM Plex](https://github.com/IBM/plex/) is licensed under the terms of the [SIL Open Font License Version 1.1](https://github.com/IBM/plex/blob/master/LICENSE.txt).


### PR DESCRIPTION
Add verbiage to README file for this project to mention the license that [MySQL Connector/Python](https://github.com/mysql/mysql-connector-python) is distributed under along with the [Universal FOSS Exception](https://oss.oracle.com/licenses/universal-foss-exception/) that allows applications that only interface with MySQL Connector/Python are permitted to be distributed under an OSI-approved license or a license categorized by the Free Software Foundation (FSF).